### PR TITLE
Fix ArrayOutOfBoundsException when constructing TcpHeader

### DIFF
--- a/pcap4j-core/src/main/java/org/pcap4j/packet/TcpPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/TcpPacket.java
@@ -681,6 +681,18 @@ public final class TcpPacket extends AbstractPacket {
       }
 
       int paddingLength = headerLength - currentOffsetInHeader;
+      if (paddingLength < 0) {
+          StringBuilder sb = new StringBuilder(110);
+          sb.append("AN option in the header is larger than the header(")
+            .append(headerLength)
+            .append(" bytes). data: ")
+            .append(ByteArrays.toHexString(rawData, " "))
+            .append(", offset: ")
+            .append(offset)
+            .append(", length: ")
+            .append(length);
+          throw new IllegalRawDataException(sb.toString());
+      }
       if (paddingLength != 0) {
         this.padding
           = ByteArrays.getSubArray(rawData, currentOffsetInHeader + offset, paddingLength);


### PR DESCRIPTION
If the TCP options are invalid and cross over the end of the TCP header, then the paddingLength is negative and then things go bad very quickly. This change adds a check for this case, and throws a more reasonable exception (IllegalRawDataException)
