### PR TITLE
Add IllegalRawDataException to be thrown from many methods.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+testdata/

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV4DestinationUnreachablePacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV4DestinationUnreachablePacket.java
@@ -64,7 +64,7 @@ extends IcmpV4InvokingPacketPacket {
 
   private IcmpV4DestinationUnreachablePacket(
     IcmpV4DestinationUnreachableHeader header, byte[] rawData, int payloadOffset, int payloadLength
-  ) {
+  ) throws IllegalRawDataException {
     super(rawData, payloadOffset, payloadLength);
     this.header = header;
   }

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV4InvokingPacketPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV4InvokingPacketPacket.java
@@ -44,8 +44,9 @@ abstract class IcmpV4InvokingPacketPacket extends AbstractPacket {
    * @param rawData
    * @param payloadOffset
    * @param payloadLength
+   * @throws IllegalRawDataException
    */
-  protected IcmpV4InvokingPacketPacket(byte[] rawData, int payloadOffset, int payloadLength) {
+  protected IcmpV4InvokingPacketPacket(byte[] rawData, int payloadOffset, int payloadLength) throws IllegalRawDataException {
     Packet p = PacketFactories.getFactory(Packet.class, EtherType.class)
                  .newInstance(rawData, payloadOffset, payloadLength, EtherType.IPV4);
 

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV4ParameterProblemPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV4ParameterProblemPacket.java
@@ -63,7 +63,7 @@ public final class IcmpV4ParameterProblemPacket extends IcmpV4InvokingPacketPack
 
   private IcmpV4ParameterProblemPacket(
     IcmpV4ParameterProblemHeader header, byte[] rawData, int payloadOffset, int payloadLength
-  ) {
+  ) throws IllegalRawDataException {
     super(rawData, payloadOffset, payloadLength);
     this.header = header;
   }

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV4RedirectPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV4RedirectPacket.java
@@ -61,7 +61,7 @@ public final class IcmpV4RedirectPacket extends IcmpV4InvokingPacketPacket {
 
   private IcmpV4RedirectPacket(
     IcmpV4RedirectHeader header, byte[] rawData, int payloadOffset, int payloadLength
-  ) {
+  ) throws IllegalRawDataException {
     super(rawData, payloadOffset, payloadLength);
     this.header = header;
   }

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV4SourceQuenchPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV4SourceQuenchPacket.java
@@ -62,7 +62,7 @@ public final class IcmpV4SourceQuenchPacket extends IcmpV4InvokingPacketPacket {
 
   private IcmpV4SourceQuenchPacket(
     IcmpV4SourceQuenchHeader header, byte[] rawData, int payloadOffset, int payloadLength
-  ) {
+  ) throws IllegalRawDataException {
     super(rawData, payloadOffset, payloadLength);
     this.header = header;
   }

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV4TimeExceededPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV4TimeExceededPacket.java
@@ -62,7 +62,7 @@ public final class IcmpV4TimeExceededPacket extends IcmpV4InvokingPacketPacket {
 
   private IcmpV4TimeExceededPacket(
     IcmpV4TimeExceededHeader header, byte[] rawData, int payloadOffset, int payloadLength
-  ) {
+  ) throws IllegalRawDataException {
     super(rawData, payloadOffset, payloadLength);
     this.header = header;
   }

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6DestinationUnreachablePacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6DestinationUnreachablePacket.java
@@ -64,7 +64,7 @@ extends IcmpV6InvokingPacketPacket {
 
   private IcmpV6DestinationUnreachablePacket(
     IcmpV6DestinationUnreachableHeader header, byte[] rawData, int payloadOffset, int payloadLength
-  ) {
+  ) throws IllegalRawDataException {
     super(rawData, payloadOffset, payloadLength);
     this.header = header;
   }

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6InvokingPacketPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6InvokingPacketPacket.java
@@ -43,8 +43,9 @@ abstract class IcmpV6InvokingPacketPacket extends AbstractPacket {
    * @param rawData
    * @param payloadOffset
    * @param payloadLength
+   * @throws IllegalRawDataException
    */
-  protected IcmpV6InvokingPacketPacket(byte[] rawData, int payloadOffset, int payloadLength) {
+  protected IcmpV6InvokingPacketPacket(byte[] rawData, int payloadOffset, int payloadLength) throws IllegalRawDataException {
     Packet p = PacketFactories.getFactory(Packet.class, EtherType.class)
                  .newInstance(rawData, payloadOffset, payloadLength, EtherType.IPV6);
 

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6PacketTooBigPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6PacketTooBigPacket.java
@@ -62,7 +62,7 @@ public final class IcmpV6PacketTooBigPacket extends IcmpV6InvokingPacketPacket {
 
   private IcmpV6PacketTooBigPacket(
     IcmpV6PacketTooBigHeader header, byte[] rawData, int payloadOffset, int payloadLength
-  ) {
+  ) throws IllegalRawDataException {
     super(rawData, payloadOffset, payloadLength);
     this.header = header;
   }

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6ParameterProblemPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6ParameterProblemPacket.java
@@ -64,7 +64,7 @@ extends IcmpV6InvokingPacketPacket {
 
   private IcmpV6ParameterProblemPacket(
     IcmpV6ParameterProblemHeader header, byte[] rawData, int payloadOffset, int payloadLength
-  ) {
+  ) throws IllegalRawDataException {
     super(rawData, payloadOffset, payloadLength);
     this.header = header;
   }

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6TimeExceededPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6TimeExceededPacket.java
@@ -62,7 +62,7 @@ public final class IcmpV6TimeExceededPacket extends IcmpV6InvokingPacketPacket {
 
   private IcmpV6TimeExceededPacket(
     IcmpV6TimeExceededHeader header, byte[] rawData, int payloadOffset, int payloadLength
-  ) {
+  ) throws IllegalRawDataException {
     super(rawData, payloadOffset, payloadLength);
     this.header = header;
   }

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IpV6ExtDestinationOptionsPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IpV6ExtDestinationOptionsPacket.java
@@ -61,7 +61,7 @@ public final class IpV6ExtDestinationOptionsPacket extends IpV6ExtOptionsPacket 
   private IpV6ExtDestinationOptionsPacket(
     byte[] rawData, int payloadOffset, int payloadLength,
     IpV6ExtDestinationOptionsHeader optHeader
-  ) {
+  ) throws IllegalRawDataException {
     super(rawData, payloadOffset, payloadLength, optHeader.getNextHeader());
     this.header = optHeader;
   }

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IpV6ExtHopByHopOptionsPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IpV6ExtHopByHopOptionsPacket.java
@@ -61,7 +61,7 @@ public final class IpV6ExtHopByHopOptionsPacket extends IpV6ExtOptionsPacket {
   private IpV6ExtHopByHopOptionsPacket(
     byte[] rawData, int payloadOffset, int payloadLength,
     IpV6ExtHopByHopOptionsHeader optHeader
-  ) {
+  ) throws IllegalRawDataException {
     super(rawData, payloadOffset, payloadLength, optHeader.getNextHeader());
     this.header = optHeader;
   }

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IpV6ExtOptionsPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IpV6ExtOptionsPacket.java
@@ -42,10 +42,11 @@ public abstract class IpV6ExtOptionsPacket extends AbstractPacket {
    * @param payloadOffset
    * @param payloadLength
    * @param number
+   * @throws IllegalRawDataException
    */
   protected IpV6ExtOptionsPacket(
     byte[] rawData, int payloadOffset, int payloadLength, IpNumber number
-  ) {
+  ) throws IllegalRawDataException {
     this.payload
       = PacketFactories.getFactory(Packet.class, IpNumber.class)
           .newInstance(rawData, payloadOffset, payloadLength, number);

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/factory/PacketFactory.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/factory/PacketFactory.java
@@ -7,6 +7,7 @@
 
 package org.pcap4j.packet.factory;
 
+import org.pcap4j.packet.IllegalRawDataException;
 import org.pcap4j.packet.namednumber.NamedNumber;
 
 /**
@@ -23,8 +24,9 @@ public interface PacketFactory<T, N extends NamedNumber<?, ?>> {
    * @param length
    * @param number
    * @return a new data object.
+   * @throws IllegalRawDataException
    */
-  public T newInstance(byte[] rawData, int offset, int length, N number);
+  public T newInstance(byte[] rawData, int offset, int length, N number) throws IllegalRawDataException;
 
   /**
    * @param rawData

--- a/pcap4j-core/src/main/java/org/pcap4j/util/IpV4Helper.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/util/IpV4Helper.java
@@ -11,6 +11,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+
+import org.pcap4j.packet.IllegalRawDataException;
 import org.pcap4j.packet.IpV4Packet;
 import org.pcap4j.packet.IpV4Packet.IpV4Header;
 import org.pcap4j.packet.Packet;
@@ -98,8 +100,9 @@ public final class IpV4Helper {
    *
    * @param list
    * @return a defragmented packet.
+   * @throws IllegalRawDataException
    */
-  public static IpV4Packet defragment(List<IpV4Packet> list) {
+  public static IpV4Packet defragment(List<IpV4Packet> list) throws IllegalRawDataException {
     Collections.sort(list, comparator);
 
     IpV4Header lastPacketHeader = list.get(list.size() - 1).getHeader();

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/DefragmentEcho.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/DefragmentEcho.java
@@ -6,10 +6,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
+
 import org.pcap4j.core.NotOpenException;
 import org.pcap4j.core.PcapHandle;
 import org.pcap4j.core.PcapNativeException;
 import org.pcap4j.core.Pcaps;
+import org.pcap4j.packet.IllegalRawDataException;
 import org.pcap4j.packet.IpV4Packet;
 import org.pcap4j.packet.Packet;
 import org.pcap4j.packet.SimpleBuilder;
@@ -23,7 +25,7 @@ public class DefragmentEcho {
   private static final String PCAP_FILE
     = System.getProperty(PCAP_FILE_KEY, "src/main/resources/flagmentedEcho.pcap");
 
-  public static void main(String[] args) throws PcapNativeException, NotOpenException {
+  public static void main(String[] args) throws PcapNativeException, NotOpenException, IllegalRawDataException {
     PcapHandle handle = Pcaps.openOffline(PCAP_FILE);
 
     Map<Short, List<IpV4Packet>> ipV4Packets

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/Dump.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/Dump.java
@@ -1,6 +1,7 @@
 package org.pcap4j.sample;
 
 import java.io.IOException;
+
 import org.pcap4j.core.BpfProgram.BpfCompileMode;
 import org.pcap4j.core.NotOpenException;
 import org.pcap4j.core.PcapDumper;
@@ -8,6 +9,7 @@ import org.pcap4j.core.PcapHandle;
 import org.pcap4j.core.PcapNativeException;
 import org.pcap4j.core.PcapNetworkInterface;
 import org.pcap4j.core.PcapNetworkInterface.PromiscuousMode;
+import org.pcap4j.packet.IllegalRawDataException;
 import org.pcap4j.packet.Packet;
 import org.pcap4j.util.NifSelector;
 
@@ -34,7 +36,7 @@ public class Dump {
   private static final String PCAP_FILE
     = System.getProperty(PCAP_FILE_KEY, "Dump.pcap");
 
-  public static void main(String[] args) throws PcapNativeException, NotOpenException {
+  public static void main(String[] args) throws PcapNativeException, NotOpenException, IllegalRawDataException {
     String filter = args.length != 0 ? args[0] : "";
 
     System.out.println(COUNT_KEY + ": " + COUNT);

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/GetNextPacket.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/GetNextPacket.java
@@ -2,6 +2,7 @@ package org.pcap4j.sample;
 
 import java.io.IOException;
 import java.sql.Timestamp;
+
 import org.pcap4j.core.BpfProgram.BpfCompileMode;
 import org.pcap4j.core.NotOpenException;
 import org.pcap4j.core.PcapHandle;
@@ -9,8 +10,10 @@ import org.pcap4j.core.PcapNativeException;
 import org.pcap4j.core.PcapNetworkInterface;
 import org.pcap4j.core.PcapNetworkInterface.PromiscuousMode;
 import org.pcap4j.core.PcapStat;
+import org.pcap4j.packet.IllegalRawDataException;
 import org.pcap4j.packet.Packet;
 import org.pcap4j.util.NifSelector;
+
 import com.sun.jna.Platform;
 
 @SuppressWarnings("javadoc")
@@ -36,7 +39,7 @@ public class GetNextPacket {
   private static final int BUFFER_SIZE
     = Integer.getInteger(BUFFER_SIZE_KEY, 1 * 1024 * 1024); // [bytes]
 
-  public static void main(String[] args) throws PcapNativeException, NotOpenException {
+  public static void main(String[] args) throws PcapNativeException, NotOpenException, IllegalRawDataException {
     String filter = args.length != 0 ? args[0] : "";
 
     System.out.println(COUNT_KEY + ": " + COUNT);

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/GetNextPacketEx.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/GetNextPacketEx.java
@@ -4,12 +4,14 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.concurrent.TimeoutException;
+
 import org.pcap4j.core.BpfProgram.BpfCompileMode;
 import org.pcap4j.core.NotOpenException;
 import org.pcap4j.core.PcapHandle;
 import org.pcap4j.core.PcapNativeException;
 import org.pcap4j.core.PcapNetworkInterface;
 import org.pcap4j.core.PcapNetworkInterface.PromiscuousMode;
+import org.pcap4j.packet.IllegalRawDataException;
 import org.pcap4j.packet.Packet;
 import org.pcap4j.util.NifSelector;
 
@@ -31,7 +33,7 @@ public class GetNextPacketEx {
   private static final int SNAPLEN
     = Integer.getInteger(SNAPLEN_KEY, 65536); // [bytes]
 
-  public static void main(String[] args) throws PcapNativeException, NotOpenException {
+  public static void main(String[] args) throws PcapNativeException, NotOpenException, IllegalRawDataException {
     String filter = args.length != 0 ? args[0] : "";
 
     System.out.println(COUNT_KEY + ": " + COUNT);

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/PcapFileMerger.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/PcapFileMerger.java
@@ -5,12 +5,13 @@ import org.pcap4j.core.PcapDumper;
 import org.pcap4j.core.PcapHandle;
 import org.pcap4j.core.PcapNativeException;
 import org.pcap4j.core.Pcaps;
+import org.pcap4j.packet.IllegalRawDataException;
 import org.pcap4j.packet.Packet;
 
 @SuppressWarnings("javadoc")
 public class PcapFileMerger {
 
-  public static void main(String[] args) throws PcapNativeException, NotOpenException {
+  public static void main(String[] args) throws PcapNativeException, NotOpenException, IllegalRawDataException {
     // args: pcap file list
 
     PcapDumper dumper = null;

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/ReadPacketFile.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/ReadPacketFile.java
@@ -3,10 +3,12 @@ package org.pcap4j.sample;
 import java.io.EOFException;
 import java.sql.Timestamp;
 import java.util.concurrent.TimeoutException;
+
 import org.pcap4j.core.NotOpenException;
 import org.pcap4j.core.PcapHandle;
 import org.pcap4j.core.PcapNativeException;
 import org.pcap4j.core.Pcaps;
+import org.pcap4j.packet.IllegalRawDataException;
 import org.pcap4j.packet.Packet;
 
 @SuppressWarnings("javadoc")
@@ -19,7 +21,7 @@ public class ReadPacketFile {
   private static final String PCAP_FILE
     = System.getProperty(PCAP_FILE_KEY, "src/main/resources/echoAndEchoReply.pcap");
 
-  public static void main(String[] args) throws PcapNativeException, NotOpenException {
+  public static void main(String[] args) throws PcapNativeException, NotOpenException, IllegalRawDataException {
     PcapHandle handle = Pcaps.openOffline(PCAP_FILE);
 
     for (int i = 0; i < COUNT; i++) {


### PR DESCRIPTION
This change is essentially no code change, but just declares that IllegalRawDataException can be thrown from the newInstance method of PacketFactory. Once you do this, there are several other methods that need to be declared as throwing IllegalRawDataException.

I also added the testdata directory into the .gitignore so that git is happy after you build.

This version builds and passes the self-tests.
