### PR TITLE
Add packet fuzzing to the test cases. Fix various crashes exposed by this

### DIFF
--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IpV4Packet.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IpV4Packet.java
@@ -7,11 +7,15 @@
 
 package org.pcap4j.packet;
 
-import static org.pcap4j.util.ByteArrays.*;
+import static org.pcap4j.util.ByteArrays.BYTE_SIZE_IN_BYTES;
+import static org.pcap4j.util.ByteArrays.INET4_ADDRESS_SIZE_IN_BYTES;
+import static org.pcap4j.util.ByteArrays.SHORT_SIZE_IN_BYTES;
+
 import java.io.Serializable;
 import java.net.Inet4Address;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.pcap4j.packet.factory.PacketFactories;
 import org.pcap4j.packet.namednumber.IpNumber;
 import org.pcap4j.packet.namednumber.IpV4OptionType;
@@ -75,6 +79,9 @@ public final class IpV4Packet extends AbstractPacket {
       if (payloadLength > remainingRawDataLength) {
         payloadLength = remainingRawDataLength;
       }
+    }
+    if (payloadLength > 0) {
+
 
       if (header.getMoreFragmentFlag() || header.getFlagmentOffset() != 0) {
         this.payload
@@ -568,12 +575,15 @@ public final class IpV4Packet extends AbstractPacket {
         options.add(newOne);
         currentOffsetInHeader += newOne.length();
 
-        if (newOne.getType().equals(IpV4OptionType.END_OF_OPTION_LIST)) {
+        if (newOne.getType() == null || newOne.getType().equals(IpV4OptionType.END_OF_OPTION_LIST)) {
           break;
         }
       }
 
       int paddingLength = headerLength - currentOffsetInHeader;
+      if (paddingLength < 0) {
+          throw new IllegalRawDataException("Negative padding length");
+      }
       if (paddingLength != 0) {
         this.padding
           = ByteArrays.getSubArray(rawData, currentOffsetInHeader + offset, paddingLength);

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/TcpPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/TcpPacket.java
@@ -675,7 +675,7 @@ public final class TcpPacket extends AbstractPacket {
         options.add(newOne);
         currentOffsetInHeader += newOne.length();
 
-        if (newOne.getKind().equals(TcpOptionKind.END_OF_OPTION_LIST)) {
+        if (newOne.getKind() == null || newOne.getKind().equals(TcpOptionKind.END_OF_OPTION_LIST)) {
           break;
         }
       }

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/UdpPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/UdpPacket.java
@@ -58,6 +58,8 @@ public final class UdpPacket extends AbstractPacket {
       if (payloadLength > length - header.length()) {
         payloadLength = length - header.length();
       }
+    }
+    if (payloadLength > 0) {
 
       this.payload
         = PacketFactories.getFactory(Packet.class, UdpPort.class)

--- a/pcap4j-packettest/src/test/java/org/pcap4j/packet/ArpPacketTest.java
+++ b/pcap4j-packettest/src/test/java/org/pcap4j/packet/ArpPacketTest.java
@@ -1,8 +1,10 @@
 package org.pcap4j.packet;
 
 import static org.junit.Assert.*;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -155,5 +157,12 @@ public class ArpPacketTest extends AbstractPacketTest {
     }
 
   }
+
+  @Test
+  public void testNewPacketRandom() {
+      RandomPacketTest.testClass(ArpPacket.class, packet);
+  }
+
+
 
 }

--- a/pcap4j-packettest/src/test/java/org/pcap4j/packet/Dot1qVlanTaggedPacketTest.java
+++ b/pcap4j-packettest/src/test/java/org/pcap4j/packet/Dot1qVlanTaggedPacketTest.java
@@ -1,8 +1,10 @@
 package org.pcap4j.packet;
 
 import static org.junit.Assert.*;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -101,6 +103,11 @@ public class Dot1qVlanTaggedPacketTest extends AbstractPacketTest {
     } catch (IllegalRawDataException e) {
       throw new AssertionError(e);
     }
+  }
+
+  @Test
+  public void testNewPacketRandom() {
+      RandomPacketTest.testClass(Dot1qVlanTagPacket.class, packet);
   }
 
   @Test

--- a/pcap4j-packettest/src/test/java/org/pcap4j/packet/EthernetPacketTest.java
+++ b/pcap4j-packettest/src/test/java/org/pcap4j/packet/EthernetPacketTest.java
@@ -7,8 +7,10 @@
 package org.pcap4j.packet;
 
 import static org.junit.Assert.*;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -111,6 +113,12 @@ public class EthernetPacketTest extends AbstractPacketTest {
       throw new AssertionError(e);
     }
   }
+
+  @Test
+  public void testNewPacketRandom() {
+      RandomPacketTest.testClass(EthernetPacket.class, packet);
+  }
+
 
   @Test
   public void testGetHeader() {

--- a/pcap4j-packettest/src/test/java/org/pcap4j/packet/IcmpV4CommonPacketTest.java
+++ b/pcap4j-packettest/src/test/java/org/pcap4j/packet/IcmpV4CommonPacketTest.java
@@ -1,9 +1,11 @@
 package org.pcap4j.packet;
 
 import static org.junit.Assert.*;
+
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -107,6 +109,11 @@ public class IcmpV4CommonPacketTest extends AbstractPacketTest {
     } catch (IllegalRawDataException e) {
       throw new AssertionError(e);
     }
+  }
+
+  @Test
+  public void testNewPacketRandom() {
+      RandomPacketTest.testClass(IcmpV4CommonPacket.class, packet);
   }
 
   @Test

--- a/pcap4j-packettest/src/test/java/org/pcap4j/packet/IcmpV6CommonPacketTest.java
+++ b/pcap4j-packettest/src/test/java/org/pcap4j/packet/IcmpV6CommonPacketTest.java
@@ -1,9 +1,11 @@
 package org.pcap4j.packet;
 
 import static org.junit.Assert.*;
+
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -113,6 +115,11 @@ public class IcmpV6CommonPacketTest extends AbstractPacketTest {
     } catch (IllegalRawDataException e) {
       throw new AssertionError(e);
     }
+  }
+
+  @Test
+  public void testNewPacketRandom() {
+      RandomPacketTest.testClass(IcmpV6CommonPacket.class, packet);
   }
 
   @Test

--- a/pcap4j-packettest/src/test/java/org/pcap4j/packet/IpV4PacketTest.java
+++ b/pcap4j-packettest/src/test/java/org/pcap4j/packet/IpV4PacketTest.java
@@ -1,6 +1,12 @@
 package org.pcap4j.packet;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.FileReader;
@@ -11,6 +17,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -180,6 +187,11 @@ public class IpV4PacketTest extends AbstractPacketTest {
     } catch (IllegalRawDataException e) {
       throw new AssertionError(e);
     }
+  }
+
+  @Test
+  public void testNewPacketRandom() {
+      RandomPacketTest.testClass(IpV4Packet.class, packet1);
   }
 
   @Test

--- a/pcap4j-packettest/src/test/java/org/pcap4j/packet/IpV6PacketTest.java
+++ b/pcap4j-packettest/src/test/java/org/pcap4j/packet/IpV6PacketTest.java
@@ -1,9 +1,11 @@
 package org.pcap4j.packet;
 
 import static org.junit.Assert.*;
+
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -117,6 +119,12 @@ public class IpV6PacketTest extends AbstractPacketTest {
       throw new AssertionError(e);
     }
   }
+
+  @Test
+  public void testNewPacketRandom() {
+      RandomPacketTest.testClass(IpV6Packet.class, packet);
+  }
+
 
   @Test
   public void testGetHeader() {

--- a/pcap4j-packettest/src/test/java/org/pcap4j/packet/RandomPacketTest.java
+++ b/pcap4j-packettest/src/test/java/org/pcap4j/packet/RandomPacketTest.java
@@ -1,0 +1,178 @@
+package org.pcap4j.packet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Utility class to assist in testing random modifications to packets to
+ * ensure robustness of the parsers.
+ *
+ * @author philip
+ *
+ */
+public class RandomPacketTest {
+    private static Random r = new Random();
+
+    /**
+     * @param clazz			The Packet class to test
+     * @param original		A packet of the right type with data in it
+     * @throws NoSuchMethodException
+     * @throws SecurityException
+     */
+    @SuppressWarnings("unused")
+    public static void testClass(Class<? extends Packet> clazz, Packet original) {
+        Map<String, Integer> failures = new HashMap<String, Integer>();
+        Map<String, StackTracePrinter> details = new HashMap<String, StackTracePrinter>();
+        Method newPacket;
+        try {
+            newPacket = clazz.getMethod("newPacket", byte[].class, int.class, int.class);
+        } catch (SecurityException e) {
+            assertNull(e);
+            return;
+        } catch (NoSuchMethodException e) {
+            assertNull(e);
+            return;
+        }
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Task theTask = new Task(10000, newPacket, original);
+        Future<String> future = executor.submit(theTask);
+        String result = null;
+
+        for (int loop = 0; loop < 2; loop++) {
+            try {
+                result = future.get(30, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                if (loop == 0) {
+                    theTask.shutdown();
+                } else {
+                    executor.shutdownNow();
+                    assertNull("Timed out. Possible loop?", e);
+                }
+            } catch (InterruptedException e) {
+                executor.shutdownNow();
+                assertNull(e);
+            } catch (ExecutionException e) {
+                executor.shutdownNow();
+                if (e.getCause() instanceof RuntimeException) {
+                    throw (RuntimeException) e.getCause();
+                }
+
+                if (e.getCause() instanceof AssertionError) {
+                    throw (AssertionError) e.getCause();
+                }
+                assertNull(e.toString(), e);
+            }
+        }
+
+        executor.shutdownNow();
+
+        System.out.println(result);
+
+    }
+
+    private static void testMethod(Method newPacket, byte[] data) throws Throwable  {
+        try {
+            newPacket.invoke(null, data, 0, data.length);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    private static class StackTracePrinter {
+        Throwable t;
+        byte[] data;
+
+        public StackTracePrinter(Throwable t, byte[] data) {
+            this.t = t;
+            this.data = data;
+        }
+
+        public String toString() {
+            StringWriter sw = new StringWriter();
+            for (byte b: data) {
+                sw.append(String.format("%02X ", b));
+            }
+            sw.append("\n");
+            t.printStackTrace(new PrintWriter(sw));
+            return sw.toString();
+        }
+    }
+
+    private static class Task implements Callable<String> {
+        private Method newPacket;
+        private Packet original;
+        private int loopCount;
+        private boolean shutdown;
+
+        public Task(int loopCount, Method newPacket, Packet original) {
+            this.loopCount = loopCount;
+            this.newPacket = newPacket;
+            this.original = original;
+        }
+
+        public void shutdown() {
+            shutdown = true;
+        }
+
+        @Override
+        public String call() throws Exception {
+            shutdown = false;
+            Map<String, Integer> failures = new HashMap<String, Integer>();
+            Map<String, StackTracePrinter> details = new HashMap<String, StackTracePrinter>();
+            for (int i = 0; i < loopCount && !shutdown; i++) {
+                byte[] data = original.getRawData();
+
+                for (int j = r.nextInt(4); j >= 0; j-- ) {
+                    data[r.nextInt(data.length)] ^= 1 << r.nextInt(8);
+                }
+
+                if (r.nextInt(3) == 0) {
+                    // Lets swap a chunk of bytes
+                    int len = r.nextInt(8) + 1;
+                    int pos1 = r.nextInt(data.length - len);
+                    int pos2 = r.nextInt(data.length - len);
+
+                    byte[] buff = new byte[len];
+                    System.arraycopy(data, pos1, buff, 0, len);
+                    System.arraycopy(data, pos2, data, pos1, len);
+                    System.arraycopy(buff, 0, data, pos2, len);
+                }
+                try {
+                    testMethod(newPacket, data);
+                } catch (IllegalRawDataException e) {
+
+                } catch (Throwable e) {
+                    String name = e.getClass().getCanonicalName();
+                    Integer count = failures.get(name);
+                    if (count == null) {
+                        count = 0;
+                    }
+                    failures.put(name, count + 1);
+                    if (details.get(name) == null) {
+                        details.put(name, new StackTracePrinter(e, data));
+                    }
+                }
+            }
+            assertEquals("Got failures: " + failures + "\n" + details, 0, failures.size());
+
+            return String.format("Processed %d randomized packets", loopCount);
+        }
+    }
+
+}

--- a/pcap4j-packettest/src/test/java/org/pcap4j/packet/TcpPacketTest.java
+++ b/pcap4j-packettest/src/test/java/org/pcap4j/packet/TcpPacketTest.java
@@ -1,12 +1,14 @@
 package org.pcap4j.packet;
 
 import static org.junit.Assert.*;
+
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -193,6 +195,12 @@ public class TcpPacketTest extends AbstractPacketTest {
       throw new AssertionError(e);
     }
   }
+
+  @Test
+  public void testNewPacketRandom() {
+      RandomPacketTest.testClass(TcpPacket.class, packet);
+  }
+
 
   @Test
   public void testGetHeader() {

--- a/pcap4j-packettest/src/test/java/org/pcap4j/packet/UdpPacketTest.java
+++ b/pcap4j-packettest/src/test/java/org/pcap4j/packet/UdpPacketTest.java
@@ -1,9 +1,11 @@
 package org.pcap4j.packet;
 
 import static org.junit.Assert.*;
+
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -113,6 +115,11 @@ public class UdpPacketTest extends AbstractPacketTest {
     } catch (IllegalRawDataException e) {
       throw new AssertionError(e);
     }
+  }
+
+  @Test
+  public void testNewPacketRandom() {
+      RandomPacketTest.testClass(UdpPacket.class, packet);
   }
 
   @Test


### PR DESCRIPTION
I added a utility class (RandomPacketTest) to the test cases that does some simple packet fuzzing and then tries to construct the packets based on the fuzzed data.

This exposed a number of crashes, and this pull request fixes all of those. 
