### PR TITLE
Multiple code improvements - squid:S135, squid:S1905, squid:UselessParenthesesCheck

### DIFF
--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IpV4Packet.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IpV4Packet.java
@@ -423,6 +423,8 @@ public final class IpV4Packet extends AbstractPacket {
      */
     private static final long serialVersionUID = -7583326842445453539L;
 
+    private static final Logger logger = LoggerFactory.getLogger(IpV4Header.class);
+
     private static final int VERSION_AND_IHL_OFFSET
       = 0;
     private static final int VERSION_AND_IHL_SIZE
@@ -560,11 +562,11 @@ public final class IpV4Packet extends AbstractPacket {
 
       this.options = new ArrayList<IpV4Option>();
       int currentOffsetInHeader = OPTIONS_OFFSET;
-      while (currentOffsetInHeader < headerLength) {
-        IpV4OptionType type
-          = IpV4OptionType.getInstance(rawData[currentOffsetInHeader + offset]);
-        IpV4Option newOne;
-        try {
+      try {
+        while (currentOffsetInHeader < headerLength) {
+          IpV4OptionType type
+            = IpV4OptionType.getInstance(rawData[currentOffsetInHeader + offset]);
+          IpV4Option newOne;
           newOne = PacketFactories
                      .getFactory(IpV4Option.class, IpV4OptionType.class)
                         .newInstance(
@@ -573,18 +575,16 @@ public final class IpV4Packet extends AbstractPacket {
                            headerLength - currentOffsetInHeader,
                            type
                          );
-        } catch (Exception e) {
-          break;
-        }
+          options.add(newOne);
+          currentOffsetInHeader += newOne.length();
 
-        options.add(newOne);
-        currentOffsetInHeader += newOne.length();
-
-        if (newOne.getType().equals(IpV4OptionType.END_OF_OPTION_LIST)) {
-          break;
+          if (newOne.getType().equals(IpV4OptionType.END_OF_OPTION_LIST)) {
+            break;
+          }
         }
+      } catch (Exception e) {
+        logger.info(e.getMessage());
       }
-
       int paddingLength = headerLength - currentOffsetInHeader;
       if (paddingLength != 0) {
         this.padding

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/Ssh2DisconnectPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/Ssh2DisconnectPacket.java
@@ -194,7 +194,7 @@ public final class Ssh2DisconnectPacket extends AbstractPacket {
       int currentOffset = 1 + offset;
       int remainingLength = length - 1;
       this.reasonCode
-        = Ssh2DisconnectionReasonCode.getInstance((ByteArrays.getInt(rawData, currentOffset)));
+        = Ssh2DisconnectionReasonCode.getInstance(ByteArrays.getInt(rawData, currentOffset));
       currentOffset += INT_SIZE_IN_BYTES;
       remainingLength -= INT_SIZE_IN_BYTES;
       this.description = new Ssh2String(rawData, currentOffset, remainingLength);

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/Ssh2NewKeysPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/Ssh2NewKeysPacket.java
@@ -66,12 +66,12 @@ public final class Ssh2NewKeysPacket extends AbstractPacket {
 
   @Override
   public boolean equals(Object obj) {
-    return ((Object)this).equals(obj);
+    return this.equals(obj);
   }
 
   @Override
   protected int calcHashCode() {
-    return ((Object)this).hashCode();
+    return this.hashCode();
   }
 
   // Override deserializer to keep singleton
@@ -171,12 +171,12 @@ public final class Ssh2NewKeysPacket extends AbstractPacket {
 
     @Override
     public boolean equals(Object obj) {
-      return ((Object)this).equals(obj);
+      return this.equals(obj);
     }
 
     @Override
     protected int calcHashCode() {
-      return ((Object)this).hashCode();
+      return this.hashCode();
     }
 
     // Override deserializer to keep singleton

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/TcpPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/TcpPacket.java
@@ -21,6 +21,8 @@ import org.pcap4j.packet.namednumber.IpNumber;
 import org.pcap4j.packet.namednumber.TcpOptionKind;
 import org.pcap4j.packet.namednumber.TcpPort;
 import org.pcap4j.util.ByteArrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Kaito Yamada
@@ -535,7 +537,7 @@ public final class TcpPacket extends AbstractPacket {
      * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      */
 
-
+    private static final Logger logger = LoggerFactory.getLogger(TcpHeader.class);
     /**
      *
      */
@@ -664,11 +666,11 @@ public final class TcpPacket extends AbstractPacket {
 
       this.options = new ArrayList<TcpOption>();
       int currentOffsetInHeader = OPTIONS_OFFSET;
-      while (currentOffsetInHeader < headerLength) {
-        TcpOptionKind kind
-          = TcpOptionKind.getInstance(rawData[currentOffsetInHeader + offset]);
-        TcpOption newOne;
-        try {
+      try {
+        while (currentOffsetInHeader < headerLength) {
+          TcpOptionKind kind
+            = TcpOptionKind.getInstance(rawData[currentOffsetInHeader + offset]);
+          TcpOption newOne;
           newOne = PacketFactories
                      .getFactory(TcpOption.class, TcpOptionKind.class)
                         .newInstance(
@@ -677,16 +679,16 @@ public final class TcpPacket extends AbstractPacket {
                            headerLength - currentOffsetInHeader,
                            kind
                          );
-        } catch (Exception e) {
-          break;
-        }
 
-        options.add(newOne);
-        currentOffsetInHeader += newOne.length();
+          options.add(newOne);
+          currentOffsetInHeader += newOne.length();
 
-        if (newOne.getKind().equals(TcpOptionKind.END_OF_OPTION_LIST)) {
-          break;
+          if (newOne.getKind().equals(TcpOptionKind.END_OF_OPTION_LIST)) {
+            break;
+          }
         }
+      } catch (Exception e) {
+        logger.info(e.getMessage());
       }
 
       int paddingLength = headerLength - currentOffsetInHeader;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S135 - Loops should not contain more than a single "break" or "continue" statement.
squid:S1905 - Redundant casts should not be used.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S135
https://dev.eclipse.org/sonar/rules/show/squid:S1905
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava