### PR TITLE
Multiple code improvements - squid:S1197, squid:S1854, squid:S1149

### DIFF
--- a/pcap4j-core/src/main/java/org/pcap4j/core/NativeMappings.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/core/NativeMappings.java
@@ -193,7 +193,7 @@ final class NativeMappings {
   static native void  pcap_freecode(bpf_program fp);
 
   // int pcap_sendpacket(pcap_t *p, const u_char *buf, int size)
-  static native int pcap_sendpacket(Pointer p, byte buf[], int size);
+  static native int pcap_sendpacket(Pointer p, byte[] buf, int size);
 
   // void pcap_close(pcap_t *p)
   static native void pcap_close(Pointer p);

--- a/pcap4j-core/src/main/java/org/pcap4j/core/Pcaps.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/core/Pcaps.java
@@ -492,16 +492,16 @@ public final class Pcaps {
       throw new NullPointerException(sb.toString());
     }
 
-    StringBuffer buf = new StringBuffer();
+    StringBuilder builder = new StringBuilder();
     byte[] address = macAddr.getAddress();
 
     for (int i = 0; i < address.length; i++) {
-      buf.append(String.format("%02x", address[i]));
-      buf.append(":");
+      builder.append(String.format("%02x", address[i]));
+      builder.append(":");
     }
-    buf.deleteCharAt(buf.length() - 1);
+    builder.deleteCharAt(builder.length() - 1);
 
-    return buf.toString();
+    return builder.toString();
   }
 
 }

--- a/pcap4j-core/src/main/java/org/pcap4j/util/LazyValue.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/util/LazyValue.java
@@ -46,7 +46,7 @@ public final class LazyValue<T1> implements Serializable {
       synchronized (thisLock) {
         result = value;
         if (result == null) {
-          result = value = command.buildValue();
+          value = command.buildValue();
         }
       }
     }

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/Docker.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/Docker.java
@@ -67,7 +67,7 @@ public class Docker {
       waitForPing();
     }
 
-    PcapNetworkInterface nif = null;
+    PcapNetworkInterface nif;
     if (NIF_NAME != null) {
       nif = Pcaps.getDevByName(NIF_NAME);
     }

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/GetNextPacket.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/GetNextPacket.java
@@ -59,7 +59,7 @@ public class GetNextPacket {
     System.out.println(NIF_NAME_KEY + ": " + NIF_NAME);
     System.out.println("\n");
 
-    PcapNetworkInterface nif = null;
+    PcapNetworkInterface nif;
     if (NIF_NAME != null) {
       nif = Pcaps.getDevByName(NIF_NAME);
     }

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/GetNextRawPacket.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/GetNextRawPacket.java
@@ -52,7 +52,7 @@ public class GetNextRawPacket {
     System.out.println(NIF_NAME_KEY + ": " + NIF_NAME);
     System.out.println("\n");
 
-    PcapNetworkInterface nif = null;
+    PcapNetworkInterface nif;
     if (NIF_NAME != null) {
       nif = Pcaps.getDevByName(NIF_NAME);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S1854 - Dead stores should be removed.
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
George Kankava