### PR TITLE
Multiple code improvements - squid:S1155, squid:S2583

### DIFF
--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IpV4InternetTimestampOptionAddressPrespecified.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IpV4InternetTimestampOptionAddressPrespecified.java
@@ -100,7 +100,7 @@ implements IpV4InternetTimestampOptionData {
     if (timestamps == null) {
       throw new NullPointerException("timestamps may not be null");
     }
-    if (address == null && timestamps.size() != 0) {
+    if (address == null && !timestamps.isEmpty()) {
       throw new IllegalArgumentException(
               "timestamps.size() must be 0 if address is null"
             );

--- a/pcap4j-core/src/main/java/org/pcap4j/util/NifSelector.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/util/NifSelector.java
@@ -40,7 +40,7 @@ public class NifSelector {
       throw new IOException(e.getMessage());
     }
 
-    if (allDevs == null || allDevs.size() == 0) {
+    if (allDevs == null || allDevs.isEmpty()) {
       throw new IOException("No NIF to capture.");
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".
You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S2583
Please let me know if you have any questions.
George Kankava