### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/pcap4j-core/src/main/java/org/pcap4j/core/NativePacketDllMappings.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/core/NativePacketDllMappings.java
@@ -47,6 +47,8 @@ final class NativePacketDllMappings {
   // VOID PacketCloseAdapter(LPADAPTER lpAdapter)
   static native void PacketCloseAdapter(Pointer lpAdapter);
 
+  private NativePacketDllMappings() {}
+
   // struct _PACKET_OID_DATA {
   //     ULONG Oid;       ///< OID code. See the Microsoft DDK documentation or the file ntddndis.h
   //                      ///< for a complete list of valid codes.

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/DefragmentEcho.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/DefragmentEcho.java
@@ -23,6 +23,8 @@ public class DefragmentEcho {
   private static final String PCAP_FILE
     = System.getProperty(PCAP_FILE_KEY, "src/main/resources/flagmentedEcho.pcap");
 
+  private DefragmentEcho() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     PcapHandle handle = Pcaps.openOffline(PCAP_FILE);
 

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/Docker.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/Docker.java
@@ -52,6 +52,8 @@ public class Docker {
   private static final boolean WAIT
     = Boolean.getBoolean(WAIT_KEY);
 
+  private Docker() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     String filter = args.length != 0 ? args[0] : "";
 

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/Dump.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/Dump.java
@@ -40,6 +40,8 @@ public class Dump {
   private static final String PCAP_FILE
     = System.getProperty(PCAP_FILE_KEY, "Dump.pcap");
 
+  private Dump() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     String filter = args.length != 0 ? args[0] : "";
 

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/DumpLoop.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/DumpLoop.java
@@ -33,6 +33,8 @@ public class DumpLoop {
   private static final String PCAP_FILE
     = System.getProperty(PCAP_FILE_KEY, "DumpLoop.pcap");
 
+  private DumpLoop() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     String filter = args.length != 0 ? args[0] : "";
 

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/GetNextPacket.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/GetNextPacket.java
@@ -48,6 +48,8 @@ public class GetNextPacket {
   private static final String NIF_NAME
     = System.getProperty(NIF_NAME_KEY);
 
+  private GetNextPacket() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     String filter = args.length != 0 ? args[0] : "";
 

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/GetNextPacketEx.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/GetNextPacketEx.java
@@ -30,6 +30,8 @@ public class GetNextPacketEx {
   private static final int SNAPLEN
     = Integer.getInteger(SNAPLEN_KEY, 65536); // [bytes]
 
+  private GetNextPacketEx() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     String filter = args.length != 0 ? args[0] : "";
 

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/GetNextRawPacket.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/GetNextRawPacket.java
@@ -42,6 +42,8 @@ public class GetNextRawPacket {
   private static final String NIF_NAME
     = System.getProperty(NIF_NAME_KEY);
 
+  private GetNextRawPacket() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     String filter = args.length != 0 ? args[0] : "";
 

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/GetRawNextPacketEx.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/GetRawNextPacketEx.java
@@ -30,6 +30,8 @@ public class GetRawNextPacketEx {
   private static final int SNAPLEN
     = Integer.getInteger(SNAPLEN_KEY, 65536); // [bytes]
 
+  private GetRawNextPacketEx() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     String filter = args.length != 0 ? args[0] : "";
 

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/HeavyLoop.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/HeavyLoop.java
@@ -15,6 +15,8 @@ import org.pcap4j.util.NifSelector;
 @SuppressWarnings("javadoc")
 public class HeavyLoop {
 
+  private HeavyLoop() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     PcapNetworkInterface nif;
     try {

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/IcmpV4ErrReplyer.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/IcmpV4ErrReplyer.java
@@ -41,6 +41,8 @@ public class IcmpV4ErrReplyer {
 
   private static MacAddress MAC_ADDR = MacAddress.getByName("fe:00:00:00:00:01");
 
+  private IcmpV4ErrReplyer() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     String strAddress = args[0];
     String strType = args[1]; // 3(DESTINATION_UNREACHABLE) or 11(TIME_EXCEEDED) or 12(PARAMETER_PROBLEM)

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/Loop.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/Loop.java
@@ -31,6 +31,8 @@ public class Loop {
   private static final int SNAPLEN
     = Integer.getInteger(SNAPLEN_KEY, 65536); // [bytes]
 
+  private Loop() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     String filter = args.length != 0 ? args[0] : "";
 

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/LoopRaw.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/LoopRaw.java
@@ -31,6 +31,8 @@ public class LoopRaw {
   private static final int SNAPLEN
     = Integer.getInteger(SNAPLEN_KEY, 65536); // [bytes]
 
+  private LoopRaw() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     String filter = args.length != 0 ? args[0] : "";
 

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/PcapFileMerger.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/PcapFileMerger.java
@@ -10,6 +10,8 @@ import org.pcap4j.packet.Packet;
 @SuppressWarnings("javadoc")
 public class PcapFileMerger {
 
+  private PcapFileMerger() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     // args: pcap file list
 

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/ReadPacketFile.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/ReadPacketFile.java
@@ -19,6 +19,8 @@ public class ReadPacketFile {
   private static final String PCAP_FILE
     = System.getProperty(PCAP_FILE_KEY, "src/main/resources/echoAndEchoReply.pcap");
 
+  private ReadPacketFile() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     PcapHandle handle;
     try {

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/SendArpRequest.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/SendArpRequest.java
@@ -46,6 +46,8 @@ public class SendArpRequest {
 
   private static MacAddress resolvedAddr;
 
+  private SendArpRequest() {}
+
   public static void main(String[] args) throws PcapNativeException, NotOpenException {
     String strSrcIpAddress = "192.0.2.100"; // for InetAddress.getByName()
     String strDstIpAddress = args[0]; // for InetAddress.getByName()

--- a/pcap4j-sample/src/main/java/org/pcap4j/sample/SendFragmentedEcho.java
+++ b/pcap4j-sample/src/main/java/org/pcap4j/sample/SendFragmentedEcho.java
@@ -59,6 +59,8 @@ public class SendFragmentedEcho {
   private static final int MTU
     = Integer.getInteger(MTU_KEY, 1403); // [bytes]
 
+  private SendFragmentedEcho() {}
+
   public static void main(String[] args) throws PcapNativeException {
     String strSrcIpAddress = args[0]; // for InetAddress.getByName()
     String strSrcMacAddress = args[1]; // e.g. 12:34:56:ab:cd:ef


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava