### PR TITLE
Platform specific default values for address families and DLT_RAW

### DIFF
--- a/pcap4j-core/pom.xml
+++ b/pcap4j-core/pom.xml
@@ -41,6 +41,30 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>1.6.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4-rule</artifactId>
+      <version>1.6.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-classloading-xstream</artifactId>
+      <version>1.6.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>1.6.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.pcap4j</groupId>
       <artifactId>pcap4j-packetfactory-static</artifactId>
       <version>1.6.3</version>

--- a/pcap4j-core/src/main/java/org/pcap4j/Pcap4jPropertiesLoader.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/Pcap4jPropertiesLoader.java
@@ -7,6 +7,7 @@
 
 package org.pcap4j;
 
+import com.sun.jna.Platform;
 import org.pcap4j.util.PropertiesLoader;
 
 /**
@@ -15,119 +16,166 @@ import org.pcap4j.util.PropertiesLoader;
  */
 public final class Pcap4jPropertiesLoader {
 
-   private static final String KEY_PREFIX
-     = Pcap4jPropertiesLoader.class.getPackage().getName();
+    private static final String KEY_PREFIX
+            = Pcap4jPropertiesLoader.class.getPackage().getName();
 
-   /**
-    *
-    */
-   public static final String PCAP4J_PROPERTIES_PATH_KEY
-     = KEY_PREFIX + ".properties";
+    /**
+     *
+     */
+    public static final String PCAP4J_PROPERTIES_PATH_KEY
+            = KEY_PREFIX + ".properties";
 
-   /**
-    *
-    */
-   public static final String AF_INET_KEY = KEY_PREFIX + ".af.inet";
+    /**
+     *
+     */
+    public static final String AF_INET_KEY = KEY_PREFIX + ".af.inet";
 
-   /**
-    *
-    */
-   public static final String AF_INET6_KEY = KEY_PREFIX + ".af.inet6";
+    /**
+     *
+     */
+    public static final String AF_INET6_KEY = KEY_PREFIX + ".af.inet6";
 
-   /**
-    *
-    */
-   public static final String AF_PACKET_KEY = KEY_PREFIX + ".af.packet";
+    /**
+     *
+     */
+    public static final String AF_PACKET_KEY = KEY_PREFIX + ".af.packet";
 
-   /**
-    *
-    */
-   public static final String AF_LINK_KEY = KEY_PREFIX + ".af.link";
+    /**
+     *
+     */
+    public static final String AF_LINK_KEY = KEY_PREFIX + ".af.link";
 
-   /**
-    *
-    */
-   public static final String DLT_RAW_KEY = KEY_PREFIX + ".dlt.raw";
-
-   private static final Pcap4jPropertiesLoader INSTANCE = new Pcap4jPropertiesLoader();
-
-   private PropertiesLoader loader
-     = new PropertiesLoader(
-         System.getProperty(
-           PCAP4J_PROPERTIES_PATH_KEY,
-           KEY_PREFIX.replace('.', '/') + "/pcap4j.properties"
-         ),
-         true,
-         true
-       );
-
-  private Pcap4jPropertiesLoader() {}
-
-  /**
-   *
-   * @return the singleton instance of Pcap4jPropertiesLoader.
-   */
-  public static Pcap4jPropertiesLoader getInstance() {
-    return INSTANCE;
-  }
-
-  /**
-   *
-   * @return address family number for IPv4 addresses.
-   */
-  public Integer getAfInet() {
-    return loader.getInteger(
-             AF_INET_KEY ,
-             null
-           );
-  }
-
-  /**
-   *
-   * @return address family numbers for IPv6 addresses.
-   */
-  public Integer getAfInet6() {
-    return loader.getInteger(
-             AF_INET6_KEY ,
-             null
-           );
-  }
-
-  /**
-   * For Linux
-   *
-   * @return address family numbers for link layer addresses.
-   */
-  public Integer getAfPacket() {
-    return loader.getInteger(
-             AF_PACKET_KEY ,
-             null
-           );
-  }
-
-  /**
-   * For BSD including Mac OS X
-   *
-   * @return address family numbers for link layer addresses.
-   */
-  public Integer getAfLink() {
-    return loader.getInteger(
-             AF_LINK_KEY ,
-             null
-           );
-  }
+    /**
+     *
+     */
+    public static final String DLT_RAW_KEY = KEY_PREFIX + ".dlt.raw";
 
 
-  /**
-   * DLT_RAW
-   *
-   * @return the value of DLT_RAW
-   */
-  public Integer getDltRaw() {
-    return loader.getInteger(
-             DLT_RAW_KEY ,
-             null
-           );
-  }
+    private static final int AF_INET_DEFAULT = 2;
+
+    private static final int AF_PACKET_DEFAULT = 17;
+
+    private static final int AF_LINK_DEFAULT = 18;
+
+    private static final int DLT_RAW_DEFAULT = 12;
+
+    private static final int DLT_RAW_OPENBSD = 14;
+
+    private static final int AF_INET6_DEFAULT = 23;
+
+    private static final int AF_INET6_LINUX = 10;
+
+    private static final int AF_INET6_FREEBSD = 28;
+
+    private static final int AF_INET6_MAC = 30;
+
+    private static final Pcap4jPropertiesLoader INSTANCE = new Pcap4jPropertiesLoader();
+
+    private PropertiesLoader loader
+            = new PropertiesLoader(
+            System.getProperty(
+                    PCAP4J_PROPERTIES_PATH_KEY,
+                    KEY_PREFIX.replace('.', '/') + "/pcap4j.properties"
+            ),
+            true,
+            true
+    );
+
+    private Pcap4jPropertiesLoader() {
+    }
+
+    /**
+     * @return the singleton instance of Pcap4jPropertiesLoader.
+     */
+    public static Pcap4jPropertiesLoader getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * @return address family number for IPv4 addresses.
+     */
+    public Integer getAfInet() {
+        return loader.getInteger(
+                AF_INET_KEY,
+                AF_INET_DEFAULT
+        );
+    }
+
+    /**
+     * @return address family numbers for IPv6 addresses.
+     */
+    public Integer getAfInet6() {
+        return loader.getInteger(
+                AF_INET6_KEY,
+                getDefaultAfInet6()
+        );
+    }
+
+    /**
+     * For Linux
+     *
+     * @return address family numbers for link layer addresses.
+     */
+    public Integer getAfPacket() {
+        return loader.getInteger(
+                AF_PACKET_KEY,
+                AF_PACKET_DEFAULT
+        );
+    }
+
+    /**
+     * For BSD including Mac OS X
+     *
+     * @return address family numbers for link layer addresses.
+     */
+    public Integer getAfLink() {
+        return loader.getInteger(
+                AF_LINK_KEY,
+                AF_LINK_DEFAULT
+        );
+    }
+
+
+    /**
+     * DLT_RAW
+     *
+     * @return the value of DLT_RAW
+     */
+    public Integer getDltRaw() {
+        return loader.getInteger(
+                DLT_RAW_KEY,
+                getDefaultDltRaw()
+        );
+    }
+
+    /**
+     * @return The default address family for IPv6 addresses (platform specific)
+     */
+    private int getDefaultAfInet6() {
+        switch (Platform.getOSType()) {
+            case Platform.MAC:
+                return AF_INET6_MAC;
+            case Platform.FREEBSD:
+            case Platform.KFREEBSD:
+                return AF_INET6_FREEBSD;
+            case Platform.LINUX:
+            case Platform.ANDROID:
+                return AF_INET6_LINUX;
+            default:
+                return AF_INET6_DEFAULT;
+        }
+    }
+
+    /**
+     * @return The default value for DLT_RAW (platform specific)
+     */
+    private int getDefaultDltRaw() {
+        switch (Platform.getOSType()) {
+            case Platform.OPENBSD:
+                return DLT_RAW_OPENBSD;
+            default:
+                return DLT_RAW_DEFAULT;
+        }
+    }
 
 }

--- a/pcap4j-core/src/main/java/org/pcap4j/util/PropertiesLoader.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/util/PropertiesLoader.java
@@ -138,7 +138,7 @@ public class PropertiesLoader {
           );
         }
         else {
-          logger.warn(
+          logger.info(
             "[{}] Could not get value by {}, use default value: {}",
             new Object[] {resourceName, key, defaultValue}
           );
@@ -201,7 +201,7 @@ public class PropertiesLoader {
           }
         }
         else {
-          logger.warn(
+          logger.info(
             "[{}] Could not get value by {}, use default value: {}",
             new Object[] {resourceName, key, defaultValue}
           );
@@ -259,7 +259,7 @@ public class PropertiesLoader {
           );
         }
         else {
-          logger.warn(
+          logger.info(
             "[{}] Could not get value by {}, use default value: {}",
             new Object[] {resourceName, key, defaultValue}
           );
@@ -353,7 +353,7 @@ public class PropertiesLoader {
           }
         }
         else {
-          logger.warn(
+          logger.info(
             "[{}] Could not get value by {}, use default value: {}",
             new Object[] {resourceName, key, defaultValue}
           );
@@ -426,7 +426,7 @@ public class PropertiesLoader {
           }
         }
         else {
-          logger.warn(
+          logger.info(
             "[{}] Could not get value by {}, use default value: {}",
             new Object[] {resourceName, key, defaultValue}
           );
@@ -508,7 +508,7 @@ public class PropertiesLoader {
           }
         }
         else {
-          logger.warn(
+          logger.info(
             "[{}] Could not get value by {}, use default value: {}",
             new Object[] {resourceName, key, Arrays.toString(defaultValue)}
           );

--- a/pcap4j-core/src/test/java/org/pcap4j/Pcap4jPropertiesLoaderTest.java
+++ b/pcap4j-core/src/test/java/org/pcap4j/Pcap4jPropertiesLoaderTest.java
@@ -17,7 +17,6 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.pcap4j.Pcap4jPropertiesLoader.PCAP4J_PROPERTIES_PATH_KEY;
 
 @RunWith(Parameterized.class)
 @PrepareForTest(Platform.class)
@@ -87,7 +86,7 @@ public class Pcap4jPropertiesLoaderTest {
     }
 
     private int getExpectedDefaultAfInet6() {
-        switch (Platform.getOSType()) {
+        switch (osType) {
             case Platform.MAC:
                 return 30;
             case Platform.FREEBSD:
@@ -102,7 +101,7 @@ public class Pcap4jPropertiesLoaderTest {
     }
 
     private int getExpectedDefaultDltRaw() {
-        switch (Platform.getOSType()) {
+        switch (osType) {
             case Platform.OPENBSD:
                 return 14;
             default:

--- a/pcap4j-core/src/test/java/org/pcap4j/Pcap4jPropertiesLoaderTest.java
+++ b/pcap4j-core/src/test/java/org/pcap4j/Pcap4jPropertiesLoaderTest.java
@@ -1,4 +1,4 @@
-package org.pcap4j.core;
+package org.pcap4j;
 
 import com.sun.jna.Platform;
 import org.junit.Before;

--- a/pcap4j-core/src/test/java/org/pcap4j/Pcap4jPropertiesLoaderTest.java
+++ b/pcap4j-core/src/test/java/org/pcap4j/Pcap4jPropertiesLoaderTest.java
@@ -2,19 +2,58 @@ package org.pcap4j;
 
 import com.sun.jna.Platform;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.pcap4j.Pcap4jPropertiesLoader;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.pcap4j.util.PropertiesLoader;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.powermock.reflect.Whitebox;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.pcap4j.Pcap4jPropertiesLoader.PCAP4J_PROPERTIES_PATH_KEY;
 
+@RunWith(Parameterized.class)
+@PrepareForTest(Platform.class)
 public class Pcap4jPropertiesLoaderTest {
 
     private Pcap4jPropertiesLoader propertiesLoader;
 
+    private final int osType;
+
+    @Rule
+    public PowerMockRule powerMockRule = new PowerMockRule();
+
+    public Pcap4jPropertiesLoaderTest(int osType) {
+        this.osType = osType;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> osType() {
+        return Arrays.asList(new Object[][]{
+                {Platform.WINDOWS},
+                {Platform.MAC},
+                {Platform.LINUX},
+                {Platform.FREEBSD},
+                {Platform.OPENBSD}
+        });
+    }
+
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
+        PowerMockito.mockStatic(Platform.class);
+        PowerMockito.when(Platform.getOSType()).thenReturn(osType);
+
         this.propertiesLoader = Pcap4jPropertiesLoader.getInstance();
+
+        Whitebox.setInternalState(propertiesLoader, "loader",
+                new PropertiesLoader("org/pcap4j/pcap4j-test.properties", false, false));
     }
 
     @Test

--- a/pcap4j-core/src/test/java/org/pcap4j/core/Pcap4jPropertiesLoaderTest.java
+++ b/pcap4j-core/src/test/java/org/pcap4j/core/Pcap4jPropertiesLoaderTest.java
@@ -1,0 +1,74 @@
+package org.pcap4j.core;
+
+import com.sun.jna.Platform;
+import org.junit.Before;
+import org.junit.Test;
+import org.pcap4j.Pcap4jPropertiesLoader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class Pcap4jPropertiesLoaderTest {
+
+    private Pcap4jPropertiesLoader propertiesLoader;
+
+    @Before
+    public void setUp() {
+        this.propertiesLoader = Pcap4jPropertiesLoader.getInstance();
+    }
+
+    @Test
+    public void testHasDefaultAfInet() {
+        assertNotNull(propertiesLoader.getAfInet());
+        assertEquals(2, (int)propertiesLoader.getAfInet());
+    }
+
+    @Test
+    public void testHasDefaultAfInet6() {
+        assertNotNull(propertiesLoader.getAfInet6());
+        assertEquals(getExpectedDefaultAfInet6(), (int)propertiesLoader.getAfInet6());
+    }
+
+    @Test
+    public void testHasDefaultAfPacket() {
+        assertNotNull(propertiesLoader.getAfPacket());
+        assertEquals(17, (int)propertiesLoader.getAfPacket());
+    }
+
+    @Test
+    public void testHasDefaultAfLink() {
+        assertNotNull(propertiesLoader.getAfLink());
+        assertEquals(18, (int)propertiesLoader.getAfLink());
+    }
+
+    @Test
+    public void testHasDefaultDltRaw() {
+        assertNotNull(propertiesLoader.getDltRaw());
+        assertEquals(getExpectedDefaultDltRaw(), (int)propertiesLoader.getDltRaw());
+    }
+
+    private int getExpectedDefaultAfInet6() {
+        switch (Platform.getOSType()) {
+            case Platform.MAC:
+                return 30;
+            case Platform.FREEBSD:
+            case Platform.KFREEBSD:
+                return 28;
+            case Platform.LINUX:
+            case Platform.ANDROID:
+                return 10;
+            default:
+                return 23;
+        }
+    }
+
+    private int getExpectedDefaultDltRaw() {
+        switch (Platform.getOSType()) {
+            case Platform.OPENBSD:
+                return 14;
+            default:
+                return 12;
+        }
+    }
+
+}

--- a/pcap4j-core/src/test/resources/org/pcap4j/pcap4j-test.properties
+++ b/pcap4j-core/src/test/resources/org/pcap4j/pcap4j-test.properties
@@ -1,0 +1,6 @@
+#org.pcap4j.af.inet = 2
+#org.pcap4j.af.inet6 = 30
+#org.pcap4j.af.packet = 17
+#org.pcap4j.af.link = 18
+#org.pcap4j.dlt.raw = 12
+


### PR DESCRIPTION
Also, when default values are used, this is now logged on 'INFO' level (was 'WARN').
This should fix #75 