### PR TITLE
Added ZeroLengthException to catch acks

### DIFF
--- a/pcap4j-core/src/main/java/org/pcap4j/core/LengthZeroException.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/core/LengthZeroException.java
@@ -1,0 +1,36 @@
+/*_##########################################################################
+  _##
+  _##  Copyright (C) 2013  Pcap4J.org
+  _##
+  _##########################################################################
+*/
+
+package org.pcap4j.core;
+
+/**
+ * @author Luca Barze
+ * @since pcap4j 1.7.2
+ */
+public final class LengthZeroException extends RuntimeException {
+
+  /**
+   *
+   */
+  private static final long serialVersionUID = -3228133427989686165L;
+
+  /**
+   *
+   */
+  public LengthZeroException() {
+    super();
+  }
+
+  /**
+   *
+   * @param message message
+   */
+  public LengthZeroException(String message){
+    super(message);
+  }
+
+}

--- a/pcap4j-core/src/main/java/org/pcap4j/util/ByteArrays.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/util/ByteArrays.java
@@ -7,6 +7,8 @@
 
 package org.pcap4j.util;
 
+import org.pcap4j.core.LengthZeroException;
+
 import static java.nio.ByteOrder.*;
 
 import java.net.Inet4Address;
@@ -1046,7 +1048,8 @@ public final class ByteArrays {
    * @param offset offset
    * @param len len
    * @throws NullPointerException if the {@code arr} is null.
-   * @throws IllegalArgumentException if {@code arr} is empty or {@code len} is zero.
+   * @throws IllegalArgumentException if {@code arr} is empty.
+   * @throws LengthZeroException if {@code len} is zero.
    * @throws ArrayIndexOutOfBoundsException if {@code offset} or {@code len} is negative,
    *         or ({@code offset} + {@code len}) is greater than or equal to {@code arr.length}.
    */
@@ -1063,7 +1066,7 @@ public final class ByteArrays {
         .append(offset)
         .append(", arr: ")
         .append(toHexString(arr, ""));
-      throw new IllegalArgumentException(sb.toString());
+      throw new LengthZeroException(sb.toString());
     }
     if (offset < 0 || len < 0 || offset + len > arr.length) {
       StringBuilder sb = new StringBuilder(100);


### PR DESCRIPTION
Hello,

in our environments ACKs packages usually have length zero, so a lot of exceptions are thrown when I use this library. To clearly separate this kind of exceptions I created a new RuntimeException.

thank you for your efforts in building this library!
