### PR TITLE
Added support for setting immediate mode.

### DIFF
--- a/pcap4j-core/src/main/java/org/pcap4j/core/NativeMappings.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/core/NativeMappings.java
@@ -91,6 +91,7 @@ final class NativeMappings {
       "pcap_open_dead_with_tstamp_precision"
     );
     funcMap.put("pcap_set_tstamp_precision", "pcap_set_tstamp_precision");
+    funcMap.put("pcap_set_immediate_mode", "pcap_set_immediate_mode");
 
     NATIVE_LOAD_LIBRARY_OPTIONS.put(
       Library.OPTION_FUNCTION_MAPPER,
@@ -310,6 +311,9 @@ final class NativeMappings {
 
     // int pcap_set_tstamp_precision(pcap_t *p, int tstamp_precision)
     int pcap_set_tstamp_precision(Pointer p, int tstamp_precision);
+    
+    // int pcap_set_immediate_mode(pcap_t *p, int immediate_mode)
+    int pcap_set_immediate_mode(Pointer p, int immediate_mode);
 
   }
 

--- a/pcap4j-core/src/main/java/org/pcap4j/core/PcapHandle.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/core/PcapHandle.java
@@ -160,6 +160,17 @@ public final class PcapHandle implements Closeable {
       else {
         this.timestampPrecision = TimestampPrecision.MICRO;
       }
+      if (builder.isImmediateModeSet) {
+        try {
+          int rc = PcapLibrary.INSTANCE.pcap_set_immediate_mode(handle, builder.immediateMode ? 1 : 0);
+          if (rc != 0) {
+            throw new PcapNativeException(getError(), rc);
+          }
+        } catch (UnsatisfiedLinkError e) {
+          logger.error("Failed to instantiate PcapHandle object.", e);
+          throw new PcapNativeException("Immediate mode is not supported on this platform.");
+        }
+      }
 
       int activateRc = NativeMappings.pcap_activate(handle);
       if (activateRc < 0) {
@@ -1551,6 +1562,8 @@ public final class PcapHandle implements Closeable {
     private boolean isBufferSizeSet = false;
     private TimestampPrecision timestampPrecision = null;
     private PcapDirection direction = null;
+    private boolean immediateMode;
+    private boolean isImmediateModeSet = false;
 
     /**
      *
@@ -1660,6 +1673,25 @@ public final class PcapHandle implements Closeable {
      */
     public Builder direction(PcapDirection direction) {
       this.direction = direction;
+      return this;
+    }
+    
+    /**
+     * Set immediate mode, which allows programs to process packets as soon as
+     * they arrive.
+     * 
+     * @param immediateMode Whether immediate mode should be set on a PcapHandle
+     *                      when it is built. If true, immediate mode will be set,
+     *                      otherwise it will not be set.
+     *                      Some platforms and library versions don't support setting
+     *                      immediate mode. Calling this method in such cases may cause
+     *                      PcapNativeException at {@link #build()}. If this method isn't
+     *                      called, immediate mode will not be set {@link #build()}.
+     * @return this Builder object for method chaining.
+     */
+    public Builder immediateMode(boolean immediateMode) {
+      this.immediateMode = immediateMode;
+      this.isImmediateModeSet = true;
       return this;
     }
 


### PR DESCRIPTION
Added support for setting immediate mode,
http://www.tcpdump.org/manpages/pcap_set_immediate_mode.3pcap.html. 

Immediate mode will allow programs to process packets as soon as they
arrive. This may reduce latency when writing a request/response type application, for example answering ICMP echo requests (ping).

Immediate mode is supported from version 1.5.0 of libpcap, see this thread for more information:

http://seclists.org/tcpdump/2014/q4/57

(I did not create a new feature branch on the fork, hope it will be ok).