### PR TITLE
Generalize TcpPacket and UdpPacket to same abstract TransportPacket class

### DIFF
--- a/pcap4j-core/src/main/java/org/pcap4j/packet/TcpPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/TcpPacket.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * @author Kaito Yamada
  * @since pcap4j 0.9.12
  */
-public final class TcpPacket extends AbstractPacket {
+public final class TcpPacket extends AbstractPacket implements TransportPacket {
 
   // http://tools.ietf.org/html/rfc793
 
@@ -473,7 +473,7 @@ public final class TcpPacket extends AbstractPacket {
    * @author Kaito Yamada
    * @since pcap4j 0.9.12
    */
-  public static final class TcpHeader extends AbstractHeader {
+  public static final class TcpHeader extends AbstractHeader implements TransportHeader {
 
     /*
      *  0                              16                            31

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/TransportPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/TransportPacket.java
@@ -1,0 +1,29 @@
+package org.pcap4j.packet;
+
+import org.pcap4j.packet.namednumber.Port;
+
+/**
+ * @author Ferran Altimiras
+ */
+public interface TransportPacket extends Packet {
+
+  @Override
+  public TransportHeader getHeader();
+
+  /**
+   * The interface representing the Transport layer packet's header.
+   *
+   * @author Ferran Altimiras
+   */
+  public interface TransportHeader extends Header {
+	/**
+	 * @return Source port
+	 */
+	public Port getSrcPort();
+
+	/**
+	 * @return Destination port
+	 */
+	public Port getDstPort();
+  }
+}

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/UdpPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/UdpPacket.java
@@ -24,7 +24,7 @@ import org.pcap4j.util.ByteArrays;
  * @author Kaito Yamada
  * @since pcap4j 0.9.1
  */
-public final class UdpPacket extends AbstractPacket {
+public final class UdpPacket extends AbstractPacket implements TransportPacket {
 
   /**
    *
@@ -310,7 +310,7 @@ public final class UdpPacket extends AbstractPacket {
    * @author Kaito Yamada
    * @since pcap4j 0.9.1
    */
-  public static final class UdpHeader extends AbstractHeader {
+  public static final class UdpHeader extends AbstractHeader implements TransportHeader{
 
     /*
      *  0                              16                            31

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/namednumber/Port.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/namednumber/Port.java
@@ -1,0 +1,34 @@
+package org.pcap4j.packet.namednumber;
+
+/**
+ * Transport layer Port
+ *
+ * @author Ferran Altimiras
+ */
+public abstract class Port extends NamedNumber<Short, Port> {
+
+  public Port(Short value, String name) {
+ 	super(value, name);
+  }
+
+  /**
+ * @return the value of this object as an int.
+ */
+  public int valueAsInt() {
+  	return 0xFFFF & value();
+  }
+
+  /**
+ *
+ * @return a string representation of this value.
+ */
+  @Override
+  public String valueAsString() {
+	return String.valueOf(valueAsInt());
+  }
+
+  @Override
+  public int compareTo(Port o) {
+  	return value().compareTo(o.value());
+  }
+}

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/namednumber/TcpPort.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/namednumber/TcpPort.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * @author Kaito Yamada
  * @since pcap4j 0.9.12
  */
-public final class TcpPort extends NamedNumber<Short, TcpPort> {
+public final class TcpPort extends Port {
 
   /**
    *
@@ -4835,26 +4835,4 @@ public final class TcpPort extends NamedNumber<Short, TcpPort> {
   public static TcpPort register(TcpPort port) {
     return registry.put(port.value(), port);
   }
-
-  /**
-   * @return the value of this object as an int.
-   */
-  public int valueAsInt() {
-    return 0xFFFF & value();
-  }
-
-  /**
-   *
-   * @return a string representation of this value.
-   */
-  @Override
-  public String valueAsString() {
-    return String.valueOf(valueAsInt());
-  }
-
-  @Override
-  public int compareTo(TcpPort o) {
-    return value().compareTo(o.value());
-  }
-
 }

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/namednumber/UdpPort.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/namednumber/UdpPort.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * @author Kaito Yamada
  * @since pcap4j 0.9.6
  */
-public final class UdpPort extends NamedNumber<Short, UdpPort> {
+public final class UdpPort extends Port {
 
   /**
    *
@@ -4848,27 +4848,6 @@ public final class UdpPort extends NamedNumber<Short, UdpPort> {
    */
   public static UdpPort register(UdpPort port) {
     return registry.put(port.value(), port);
-  }
-
-  /**
-   * @return the value of this object as an int.
-   */
-  public int valueAsInt() {
-    return 0xFFFF & value();
-  }
-
-  /**
-   *
-   * @return a string representation of this value.
-   */
-  @Override
-  public String valueAsString() {
-    return String.valueOf(valueAsInt());
-  }
-
-  @Override
-  public int compareTo(UdpPort o) {
-    return value().compareTo(o.value());
   }
 
 }


### PR DESCRIPTION
Like IpPacket is a common parent for IPv4 and IPv6 packets, helping to extract src ip and dst ip ignoring the version, does something similar to TcpPacket and UdpPacket with ports.