### PR TITLE
Fixed bug when having UnknownTcpOption with zero data, avoid extracti…

### DIFF
--- a/pcap4j-core/src/main/java/org/pcap4j/packet/UnknownTcpOption.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/UnknownTcpOption.java
@@ -74,7 +74,10 @@ public final class UnknownTcpOption implements TcpOption {
       throw new IllegalRawDataException(sb.toString());
     }
 
-    this.data = ByteArrays.getSubArray(rawData, 2 + offset, this.length - 2);
+    if (this.length > 2)
+      this.data = ByteArrays.getSubArray(rawData, 2 + offset, this.length - 2);
+    else
+      this.data = new byte[]{};
   }
 
   private UnknownTcpOption(Builder builder) {


### PR DESCRIPTION
Fixed bug when having UnknownTcpOption with zero data, avoid extracting sub array from the raw data if the length is 2 then what have happened was that there is an attempt to get sub array with length zero (2-2, see the code)

If the length is equal to 2 then it means there is no data, an empty data array will be created.

I had a lot of TCP packets that throws exception due to this issue that eventually caused for increasing the memory, looks like a memory leak...