### PR TITLE
(reopen)add protocol implementations for 4 icmpv6 types:

### DIFF
--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6HomeAgentAddressDiscoveryReplyPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6HomeAgentAddressDiscoveryReplyPacket.java
@@ -1,0 +1,268 @@
+package org.pcap4j.packet;
+
+import static org.pcap4j.util.ByteArrays.INET6_ADDRESS_SIZE_IN_BYTES;
+import static org.pcap4j.util.ByteArrays.SHORT_SIZE_IN_BYTES;
+
+import java.net.Inet6Address;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.pcap4j.packet.AbstractPacket;
+import org.pcap4j.packet.IllegalRawDataException;
+import org.pcap4j.packet.Packet;
+import org.pcap4j.packet.factory.PacketFactories;
+import org.pcap4j.packet.namednumber.NotApplicable;
+import org.pcap4j.util.ByteArrays;
+
+/**
+ * Icmpv6 home agent address discovery reply packet.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc3775">RFC 3775</a>
+ * @see <a href="https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-codes-21">ICMPv6 Parameters</a>
+ * @author Leo Ma
+ * @since pcap4j 1.7.5
+ */
+public class IcmpV6HomeAgentAddressDiscoveryReplyPacket extends AbstractPacket {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 8080366373921919970L;
+
+    private final IcmpV6HomeAgentAddressDiscoveryReplyHeader header;
+
+    /**
+     * A static factory method.
+     * This method validates the arguments by {@link ByteArrays#validateBounds(byte[], int, int)},
+     * which may throw exceptions undocumented here.
+     * 
+     * @param rawData rawData
+     * @param offset offset
+     * @param length length
+     * @return a new IcmpV6HomeAgentAddressDiscoveryReplyPacket object.
+     * @throws IllegalRawDataException if parsing the raw data fails.
+     */
+    public static IcmpV6HomeAgentAddressDiscoveryReplyPacket newPacket(
+            byte[] rawData, int offset, int length) throws IllegalRawDataException {
+        ByteArrays.validateBounds(rawData, offset, length);
+        return new IcmpV6HomeAgentAddressDiscoveryReplyPacket(rawData, offset, length);
+    }
+
+    private IcmpV6HomeAgentAddressDiscoveryReplyPacket(
+            byte[] rawData, int offset, int length) throws IllegalRawDataException {
+        this.header = new IcmpV6HomeAgentAddressDiscoveryReplyHeader(rawData, offset, length);
+    }
+
+    private IcmpV6HomeAgentAddressDiscoveryReplyPacket(Builder builder) {
+        this.header = new IcmpV6HomeAgentAddressDiscoveryReplyHeader(builder);
+    }
+
+    @Override
+    public IcmpV6HomeAgentAddressDiscoveryReplyHeader getHeader() {
+        return header;
+    }
+
+    @Override
+    public Builder getBuilder() {
+        return new Builder(this);
+    }
+
+    public static final class Builder extends AbstractBuilder {
+
+        private short identifier;
+        private short reserved;
+        private List<Inet6Address> homeAgentAddresses;
+
+        /**
+         *
+         */
+        public Builder() {
+            // Do nothing, just used to create a Builder without fields setting
+        }
+
+        private Builder(IcmpV6HomeAgentAddressDiscoveryReplyPacket packet) {
+            this.identifier = packet.header.identifier;
+            this.reserved = packet.header.reserved;
+            this.homeAgentAddresses = packet.header.homeAgentAddresses;
+        }
+
+        /**
+         * @param identifier identifier
+         * @return this Builder object for method chaining.
+         */
+        public Builder identifier(short identifier) {
+            this.identifier = identifier;
+            return this;
+        }
+
+        /**
+         * @param reserved reserved
+         * @return this Builder object for method chaining.
+         */
+        public Builder reserved(short reserved) {
+            this.reserved = reserved;
+            return this;
+        }
+
+        /**
+         * @param homeAgentAddresses homeAgentAddresses
+         * @return this Builder object for method chaining.
+         */
+        public Builder homeAgentAddresses(List<Inet6Address> homeAgentAddresses) {
+            this.homeAgentAddresses = new ArrayList<Inet6Address>(homeAgentAddresses);
+            return this;
+        }
+
+        @Override
+        public IcmpV6HomeAgentAddressDiscoveryReplyPacket build() {
+            return new IcmpV6HomeAgentAddressDiscoveryReplyPacket(this);
+        }
+
+    }
+
+    public static final class IcmpV6HomeAgentAddressDiscoveryReplyHeader extends AbstractHeader {
+
+        /*
+         * 0                   1                   2                   3
+         * 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+         * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         * |           Identifier          |             Reserved          |
+         * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         * |                                                               |
+         * +                                                               +
+         * |                                                               |
+         * +                      Home Agent Addresses                     +
+         * |                                                               |
+         * +                                                               +
+         * |                                                               |
+         * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         */
+        private static final long serialVersionUID = 7184228144196703852L;
+
+        private static final int IDENTIFIER_OFFSET = 0;
+        private static final int IDENTIFIER_SIZE = SHORT_SIZE_IN_BYTES;
+        private static final int RESERVED_OFFSET = IDENTIFIER_OFFSET + IDENTIFIER_SIZE;
+        private static final int RESERVED_SIZE = SHORT_SIZE_IN_BYTES;
+        private static final int HOME_AGENT_ADDRESSES_OFFSET = RESERVED_OFFSET + RESERVED_SIZE;
+        private static final int HOME_AGENT_ADDRESSES_SIZE = INET6_ADDRESS_SIZE_IN_BYTES;
+        private static final int ICMPV6_HOME_AGENT_ADDRESS_DISCOVERY_REPLY_HEADER_MIN_SIZE = HOME_AGENT_ADDRESSES_OFFSET
+                + HOME_AGENT_ADDRESSES_SIZE;
+
+        private final short identifier;
+        private final short reserved;
+        private final List<Inet6Address> homeAgentAddresses;
+
+        private IcmpV6HomeAgentAddressDiscoveryReplyHeader(byte[] rawData, int offset, int length)
+                throws IllegalRawDataException {
+            if (length < ICMPV6_HOME_AGENT_ADDRESS_DISCOVERY_REPLY_HEADER_MIN_SIZE) {
+                StringBuilder sb = new StringBuilder();
+                sb.append("The data is too short to build an ICMPv6 Home Agent Address Discovery Reply Header(")
+                        .append(ICMPV6_HOME_AGENT_ADDRESS_DISCOVERY_REPLY_HEADER_MIN_SIZE)
+                        .append(" bytes). data: ")
+                        .append(ByteArrays.toHexString(rawData, " "))
+                        .append(", offset: ")
+                        .append(offset)
+                        .append(", length: ")
+                        .append(length);
+                throw new IllegalRawDataException(sb.toString());
+            }
+            this.identifier = ByteArrays.getShort(rawData, IDENTIFIER_OFFSET + offset);
+            this.reserved = ByteArrays.getShort(rawData, RESERVED_OFFSET + offset);
+            this.homeAgentAddresses = new ArrayList<Inet6Address>();
+            for (int i = HOME_AGENT_ADDRESSES_OFFSET; i < length; i += INET6_ADDRESS_SIZE_IN_BYTES) {
+                homeAgentAddresses.add(ByteArrays.getInet6Address(rawData, i + offset));
+            }
+        }
+
+        private IcmpV6HomeAgentAddressDiscoveryReplyHeader(Builder builder) {
+            this.identifier = builder.identifier;
+            this.reserved = builder.reserved;
+            this.homeAgentAddresses = builder.homeAgentAddresses;
+        }
+
+        public short getIdentifier() {
+            return identifier;
+        }
+
+        public int getIdentifierAsInt() {
+            return identifier & 0xFFFF;
+          }
+
+        public short getReserved() {
+            return reserved;
+        }
+
+        public List<Inet6Address> getHomeAgentAddresses() {
+            return new ArrayList<Inet6Address>(homeAgentAddresses);
+        }
+
+        @Override
+        protected List<byte[]> getRawFields() {
+            List<byte[]> rawFields = new ArrayList<byte[]>();
+            rawFields.add(ByteArrays.toByteArray(identifier));
+            rawFields.add(ByteArrays.toByteArray(reserved));
+            
+            for (Inet6Address addr : homeAgentAddresses) {
+                rawFields.add(ByteArrays.toByteArray(addr));
+            }
+            return rawFields;
+        }
+
+        @Override
+        protected int calcLength() {
+            return homeAgentAddresses.size() * INET6_ADDRESS_SIZE_IN_BYTES + HOME_AGENT_ADDRESSES_OFFSET;
+        }
+
+        @Override
+        protected String buildString() {
+            StringBuilder sb = new StringBuilder();
+            String ls = System.getProperty("line.separator");
+
+            sb.append("[ICMPv6 Home Agent Address Discovery Reply Header (")
+                    .append(length())
+                    .append(" bytes)]")
+                    .append(ls);
+            sb.append("  Identifier: ")
+                    .append(getIdentifierAsInt())
+                    .append(ls);
+            sb.append("  Reserved: ")
+                    .append(reserved)
+                    .append(ls);
+            sb.append("  HomeAgentAddresses: ");
+            for (Inet6Address addr : homeAgentAddresses) {
+                sb.append(" ")
+                        .append(addr);
+            }
+            sb.append(ls);
+            return sb.toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (!this.getClass().isInstance(obj)) {
+                return false;
+            }
+
+            IcmpV6HomeAgentAddressDiscoveryReplyHeader other = (IcmpV6HomeAgentAddressDiscoveryReplyHeader) obj;
+            return this.identifier == other.identifier
+                    && this.reserved == other.reserved
+                    && this.homeAgentAddresses.equals(other.homeAgentAddresses);
+        }
+
+        @Override
+        protected int calcHashCode() {
+            int result = 17;
+            result = 31 * result + identifier;
+            result = 31 * result + reserved;
+            result = 31 * result + homeAgentAddresses.hashCode();
+            return result;
+        }
+    }
+}

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6HomeAgentAddressDiscoveryRequestPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6HomeAgentAddressDiscoveryRequestPacket.java
@@ -1,0 +1,226 @@
+package org.pcap4j.packet;
+
+import static org.pcap4j.util.ByteArrays.SHORT_SIZE_IN_BYTES;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.pcap4j.packet.AbstractPacket;
+import org.pcap4j.packet.IllegalRawDataException;
+import org.pcap4j.packet.Packet;
+import org.pcap4j.packet.factory.PacketFactories;
+import org.pcap4j.packet.namednumber.NotApplicable;
+import org.pcap4j.util.ByteArrays;
+
+/**
+ * Icmpv6 home agent address discovery request packet.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc3775">RFC 3775</a>
+ * @see <a href="https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-codes-21">ICMPv6 Parameters</a>
+ * @author Leo Ma
+ * @since pcap4j 1.7.5
+ */
+public class IcmpV6HomeAgentAddressDiscoveryRequestPacket extends AbstractPacket {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = -4921942983336579680L;
+
+    private final IcmpV6HomeAgentAddressDiscoveryRequestHeader header;
+
+    /**
+     * A static factory method.
+     * This method validates the arguments by {@link ByteArrays#validateBounds(byte[], int, int)},
+     * which may throw exceptions undocumented here.
+     * 
+     * @param rawData rawData
+     * @param offset offset
+     * @param length length
+     * @return a new IcmpV6HomeAgentAddressDiscoveryRequestPacket object.
+     * @throws IllegalRawDataException if parsing the raw data fails.
+     */
+    public static IcmpV6HomeAgentAddressDiscoveryRequestPacket newPacket(
+            byte[] rawData, int offset, int length) throws IllegalRawDataException {
+        ByteArrays.validateBounds(rawData, offset, length);
+        return new IcmpV6HomeAgentAddressDiscoveryRequestPacket(rawData, offset, length);
+    }
+
+    private IcmpV6HomeAgentAddressDiscoveryRequestPacket(
+            byte[] rawData, int offset, int length) throws IllegalRawDataException {
+        this.header = new IcmpV6HomeAgentAddressDiscoveryRequestHeader(rawData, offset, length);
+    }
+
+    private IcmpV6HomeAgentAddressDiscoveryRequestPacket(Builder builder) {
+        this.header = new IcmpV6HomeAgentAddressDiscoveryRequestHeader(builder);
+    }
+
+    @Override
+    public IcmpV6HomeAgentAddressDiscoveryRequestHeader getHeader() {
+        return header;
+    }
+
+    @Override
+    public Builder getBuilder() {
+        return new Builder(this);
+    }
+
+    public static final class Builder extends AbstractBuilder {
+
+        private short identifier;
+        private short reserved;
+
+        /**
+         *
+         */
+        public Builder() {
+            // Do nothing, just used to create a Builder without fields setting
+        }
+
+        private Builder(IcmpV6HomeAgentAddressDiscoveryRequestPacket packet) {
+            this.identifier = packet.header.identifier;
+            this.reserved = packet.header.reserved;
+        }
+
+        /**
+         * @param identifier identifier
+         * @return this Builder object for method chaining.
+         */
+        public Builder identifier(short identifier) {
+            this.identifier = identifier;
+            return this;
+        }
+
+        /**
+         * @param reserved reserved
+         * @return this Builder object for method chaining.
+         */
+        public Builder reserved(short reserved) {
+            this.reserved = reserved;
+            return this;
+        }
+
+        @Override
+        public IcmpV6HomeAgentAddressDiscoveryRequestPacket build() {
+            return new IcmpV6HomeAgentAddressDiscoveryRequestPacket(this);
+        }
+
+    }
+
+    public static final class IcmpV6HomeAgentAddressDiscoveryRequestHeader extends AbstractHeader {
+
+        /*
+         *  0                            15                              31
+         * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         * |          Identifier           |            Reserved           |
+         * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         */
+
+        /**
+         *
+         */
+        private static final long serialVersionUID = -1367204926945263009L;
+
+        private static final int IDENTIFIER_OFFSET = 0;
+        private static final int IDENTIFIER_SIZE = SHORT_SIZE_IN_BYTES;
+        private static final int RESERVED_OFFSET = IDENTIFIER_OFFSET + IDENTIFIER_SIZE;
+        private static final int RESERVED_SIZE = SHORT_SIZE_IN_BYTES;
+        private static final int ICMPV6_HOME_AGENT_ADDRESS_DISCOVERY_REQUEST_HEADER_SIZE = RESERVED_OFFSET
+                + RESERVED_SIZE;
+
+        private final short identifier;
+        private final short reserved;
+
+        private IcmpV6HomeAgentAddressDiscoveryRequestHeader(byte[] rawData, int offset, int length)
+                throws IllegalRawDataException {
+            if (length < ICMPV6_HOME_AGENT_ADDRESS_DISCOVERY_REQUEST_HEADER_SIZE) {
+                StringBuilder sb = new StringBuilder();
+                sb.append("The data is too short to build an ICMPv6 Home Agent Address Discovery Request Header(")
+                        .append(ICMPV6_HOME_AGENT_ADDRESS_DISCOVERY_REQUEST_HEADER_SIZE)
+                        .append(" bytes). data: ")
+                        .append(ByteArrays.toHexString(rawData, " "))
+                        .append(", offset: ")
+                        .append(offset)
+                        .append(", length: ")
+                        .append(length);
+                throw new IllegalRawDataException(sb.toString());
+            }
+            this.identifier = ByteArrays.getShort(rawData, IDENTIFIER_OFFSET + offset);
+            this.reserved = ByteArrays.getShort(rawData, RESERVED_OFFSET + offset);
+        }
+
+        private IcmpV6HomeAgentAddressDiscoveryRequestHeader(Builder builder) {
+            this.identifier = builder.identifier;
+            this.reserved = builder.reserved;
+        }
+
+        public short getIdentifier() {
+            return identifier;
+        }
+
+        public int getIdentifierAsInt() {
+            return identifier & 0xFFFF;
+          }
+
+        public short getReserved() {
+            return reserved;
+        }
+
+        @Override
+        protected List<byte[]> getRawFields() {
+            List<byte[]> rawFields = new ArrayList<byte[]>();
+            rawFields.add(ByteArrays.toByteArray(identifier));
+            rawFields.add(ByteArrays.toByteArray(reserved));
+            return rawFields;
+        }
+
+        @Override
+        public int length() {
+            return ICMPV6_HOME_AGENT_ADDRESS_DISCOVERY_REQUEST_HEADER_SIZE;
+
+        }
+
+        @Override
+        protected String buildString() {
+            StringBuilder sb = new StringBuilder();
+            String ls = System.getProperty("line.separator");
+
+            sb.append("[ICMPv6 Home Agent Address Discovery Request Header (")
+                    .append(length())
+                    .append(" bytes)]")
+                    .append(ls);
+            sb.append("  Identifier: ")
+                    .append(getIdentifierAsInt())
+                    .append(ls);
+            sb.append("  Reserved: ")
+                    .append(reserved)
+                    .append(ls);
+            return sb.toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (!this.getClass().isInstance(obj)) {
+                return false;
+            }
+
+            IcmpV6HomeAgentAddressDiscoveryRequestHeader other = (IcmpV6HomeAgentAddressDiscoveryRequestHeader) obj;
+            return this.identifier == other.identifier
+                    && this.reserved == other.reserved;
+        }
+
+        @Override
+        protected int calcHashCode() {
+            int result = 17;
+            result = 31 * result + identifier;
+            result = 31 * result + reserved;
+            return result;
+        }
+    }
+}

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6MobilePrefixAdvertisementPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6MobilePrefixAdvertisementPacket.java
@@ -1,0 +1,337 @@
+package org.pcap4j.packet;
+
+import static org.pcap4j.util.ByteArrays.SHORT_SIZE_IN_BYTES;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.pcap4j.packet.AbstractPacket;
+import org.pcap4j.packet.IcmpV6CommonPacket.IpV6NeighborDiscoveryOption;
+import org.pcap4j.packet.IllegalRawDataException;
+import org.pcap4j.packet.factory.PacketFactories;
+import org.pcap4j.packet.namednumber.IpV6NeighborDiscoveryOptionType;
+import org.pcap4j.util.ByteArrays;
+
+/**
+ * Icmpv6 mobile prefix advertisement packet.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc3775">RFC 3775</a>
+ * @see <a href="https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-codes-24">ICMPv6 Parameters</a>
+ * @author Leo Ma
+ * @since pcap4j 1.7.5
+ */
+public class IcmpV6MobilePrefixAdvertisementPacket extends AbstractPacket {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 7088081805293115326L;
+
+    private final IcmpV6MobilePrefixAdvertisementHeader header;
+
+    /**
+     * A static factory method.
+     * This method validates the arguments by {@link ByteArrays#validateBounds(byte[], int, int)},
+     * which may throw exceptions undocumented here.
+     * 
+     * @param rawData rawData
+     * @param offset offset
+     * @param length length
+     * @return a new IcmpV6MobilePrefixAdvertisementPacket object.
+     * @throws IllegalRawDataException if parsing the raw data fails.
+     */
+    public static IcmpV6MobilePrefixAdvertisementPacket newPacket(
+            byte[] rawData, int offset, int length) throws IllegalRawDataException {
+        ByteArrays.validateBounds(rawData, offset, length);
+        return new IcmpV6MobilePrefixAdvertisementPacket(rawData, offset, length);
+    }
+
+    private IcmpV6MobilePrefixAdvertisementPacket(byte[] rawData, int offset, int length)
+            throws IllegalRawDataException {
+        this.header = new IcmpV6MobilePrefixAdvertisementHeader(rawData, offset, length);
+    }
+
+    private IcmpV6MobilePrefixAdvertisementPacket(Builder builder) {
+        this.header = new IcmpV6MobilePrefixAdvertisementHeader(builder);
+    }
+
+    @Override
+    public IcmpV6MobilePrefixAdvertisementHeader getHeader() {
+        return header;
+    }
+
+    @Override
+    public Builder getBuilder() {
+        return new Builder(this);
+    }
+
+    public static final class Builder extends AbstractBuilder {
+
+        private short identifier;
+        private boolean managedAddressConfigurationFlag;
+        private boolean otherStatefulConfigurationFlag;
+        private short reserved;
+        private List<IpV6NeighborDiscoveryOption> options;
+
+        /**
+         *
+         */
+        public Builder() {
+            // Do nothing, just used to create a Builder without fields setting
+        }
+
+        private Builder(IcmpV6MobilePrefixAdvertisementPacket packet) {
+            this.identifier = packet.header.identifier;
+            this.managedAddressConfigurationFlag = packet.header.managedAddressConfigurationFlag; // M field
+            this.otherStatefulConfigurationFlag = packet.header.otherStatefulConfigurationFlag; // O field
+            this.reserved = packet.header.reserved;
+            this.options = packet.header.options;
+        }
+
+        /**
+         * @param identifier identifier
+         * @return this Builder object for method chaining.
+         */
+        public Builder identifier(short identifier) {
+            this.identifier = identifier;
+            return this;
+        }
+
+        /**
+         * @param managedAddressConfigurationFlag managedAddressConfigurationFlag
+         * @return this Builder object for method chaining.
+         */
+        public Builder managedAddressConfigurationFlag(boolean managedAddressConfigurationFlag) {
+            this.managedAddressConfigurationFlag = managedAddressConfigurationFlag;
+            return this;
+        }
+
+        /**
+         * @param otherStatefulConfigurationFlag otherStatefulConfigurationFlag
+         * @return this Builder object for method chaining.
+         */
+        public Builder otherStatefulConfigurationFlag(boolean otherStatefulConfigurationFlag) {
+            this.otherStatefulConfigurationFlag = otherStatefulConfigurationFlag;
+            return this;
+        }
+
+        /**
+         * @param reserved reserved
+         * @return this Builder object for method chaining.
+         */
+        public Builder reserved(short reserved) {
+            this.reserved = reserved;
+            return this;
+        }
+
+        /**
+         * @param options options
+         * @return this Builder object for method chaining.
+         */
+        public Builder options(List<IpV6NeighborDiscoveryOption> options) {
+            this.options = options;
+            return this;
+        }
+
+        @Override
+        public IcmpV6MobilePrefixAdvertisementPacket build() {
+            return new IcmpV6MobilePrefixAdvertisementPacket(this);
+        }
+
+    }
+
+    public static final class IcmpV6MobilePrefixAdvertisementHeader extends AbstractHeader {
+
+        /*
+         *  0                   1                   2                   3
+         * 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+         * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         * |          Identifier           |M|O|        Reserved           |
+         * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         * |           Options ...
+         * +-+-+-+-+-+-+-+-+-+-+-+-+-
+         */
+
+        /**
+         *
+         */
+        private static final long serialVersionUID = -7395581536162987036L;
+
+        private static final int IDENTIFIER_OFFSET = 0;
+        private static final int IDENTIFIER_SIZE = SHORT_SIZE_IN_BYTES;
+        private static final int M_O_RESERVED_OFFSET = IDENTIFIER_OFFSET + IDENTIFIER_SIZE;
+        private static final int M_O_RESERVED_SIZE = SHORT_SIZE_IN_BYTES;
+        private static final int OPTIONS_OFFSET = M_O_RESERVED_OFFSET + M_O_RESERVED_SIZE;
+
+        private final short identifier;
+        private final boolean managedAddressConfigurationFlag; // M field
+        private final boolean otherStatefulConfigurationFlag; // O field
+        private final short reserved;
+        private final List<IpV6NeighborDiscoveryOption> options;
+
+        @SuppressWarnings("squid:S1166")
+        private IcmpV6MobilePrefixAdvertisementHeader(
+                byte[] rawData, int offset, int length) throws IllegalRawDataException {
+            if (length < OPTIONS_OFFSET) {
+                StringBuilder sb = new StringBuilder(120);
+                sb.append("The raw data must be more than ")
+                        .append(OPTIONS_OFFSET - 1).append("bytes")
+                        .append(" to build this header. raw data: ")
+                        .append(ByteArrays.toHexString(rawData, " "))
+                        .append(", offset: ")
+                        .append(offset)
+                        .append(", length: ")
+                        .append(length);
+                throw new IllegalRawDataException(sb.toString());
+            }
+            this.identifier = ByteArrays.getShort(rawData, IDENTIFIER_OFFSET + offset);
+            short tmp = ByteArrays.getShort(rawData, M_O_RESERVED_OFFSET + offset);
+            this.managedAddressConfigurationFlag = (tmp & 0x8000) != 0;
+            this.otherStatefulConfigurationFlag = (tmp & 0x4000) != 0;
+            this.reserved = (short) (0x3FFF & tmp);
+            this.options = new ArrayList<IpV6NeighborDiscoveryOption>();
+            int currentOffsetInHeader = OPTIONS_OFFSET;
+            while (currentOffsetInHeader < length) {
+                IpV6NeighborDiscoveryOptionType type = IpV6NeighborDiscoveryOptionType
+                        .getInstance(rawData[currentOffsetInHeader + offset]);
+                IpV6NeighborDiscoveryOption newOne;
+                try {
+                    newOne = PacketFactories.getFactory(IpV6NeighborDiscoveryOption.class,
+                            IpV6NeighborDiscoveryOptionType.class).newInstance(rawData, currentOffsetInHeader + offset,
+                            length - currentOffsetInHeader, type);
+                } catch (Exception e) {
+                    break;
+                }
+                options.add(newOne);
+                currentOffsetInHeader += newOne.length();
+            }
+        }
+
+        private IcmpV6MobilePrefixAdvertisementHeader(Builder builder) {
+            if ((builder.reserved & 0xC0000000) != 0) {
+                throw new IllegalArgumentException(
+                        "Invalid reserved: " + builder.reserved);
+            }
+            this.identifier = builder.identifier;
+            this.managedAddressConfigurationFlag = builder.managedAddressConfigurationFlag;
+            this.otherStatefulConfigurationFlag = builder.otherStatefulConfigurationFlag;
+            this.reserved = builder.reserved;
+            this.options = new ArrayList<IpV6NeighborDiscoveryOption>(builder.options);
+        }
+
+        public short getIdentifier() {
+            return identifier;
+        }
+
+        public int getIdentifierAsInt() {
+            return identifier & 0xFFFF;
+          }
+
+        public boolean isManagedAddressConfigurationFlag() {
+            return managedAddressConfigurationFlag;
+        }
+
+        public boolean isOtherStatefulConfigurationFlag() {
+            return otherStatefulConfigurationFlag;
+        }
+
+        public short getReserved() {
+            return reserved;
+        }
+
+        public List<IpV6NeighborDiscoveryOption> getOptions() {
+            return new ArrayList<IpV6NeighborDiscoveryOption>(options);
+        }
+
+        @Override
+        protected List<byte[]> getRawFields() {
+            List<byte[]> rawFields = new ArrayList<byte[]>();
+
+            rawFields.add(ByteArrays.toByteArray(identifier));
+            short tmp = (short) (0x3FFF & reserved);
+            if (managedAddressConfigurationFlag) {
+                tmp |= 0x8000;
+            }
+            if (otherStatefulConfigurationFlag) {
+                tmp |= 0x4000;
+            }
+            rawFields.add(ByteArrays.toByteArray(tmp));
+            for (IpV6NeighborDiscoveryOption o : options) {
+                rawFields.add(o.getRawData());
+            }
+            return rawFields;
+        }
+
+        @Override
+        protected int calcLength() {
+            int len = 0;
+            for (IpV6NeighborDiscoveryOption o : options) {
+                len += o.length();
+            }
+            return len + OPTIONS_OFFSET;
+        }
+
+        @Override
+        protected String buildString() {
+            StringBuilder sb = new StringBuilder();
+            String ls = System.getProperty("line.separator");
+
+            sb.append("[ICMPv6 Mobile Prefix Advertisement Header (")
+                    .append(length())
+                    .append(" bytes)]")
+                    .append(ls);
+            sb.append("  Identifier: ")
+                    .append(getIdentifierAsInt())
+                    .append(ls);
+            sb.append("  ManagedAddressConfigurationFlag: ")
+                    .append(managedAddressConfigurationFlag)
+                    .append(ls);
+            sb.append("  OtherStatefulConfigurationFlag: ")
+                    .append(otherStatefulConfigurationFlag)
+                    .append(ls);
+            sb.append("  Reserved: ")
+                    .append(reserved)
+                    .append(ls);
+            for (IpV6NeighborDiscoveryOption opt : options) {
+                sb.append("  Option: ")
+                        .append(opt)
+                        .append(ls);
+            }
+
+            return sb.toString();
+        }
+
+        @Override
+        @SuppressWarnings("squid:S1067")
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (!this.getClass().isInstance(obj)) {
+                return false;
+            }
+
+            IcmpV6MobilePrefixAdvertisementHeader other = (IcmpV6MobilePrefixAdvertisementHeader) obj;
+            return this.identifier == other.identifier
+                    && this.managedAddressConfigurationFlag == other.managedAddressConfigurationFlag
+                    && this.otherStatefulConfigurationFlag == other.otherStatefulConfigurationFlag
+                    && this.reserved == other.reserved
+                    && options.equals(other.options);
+        }
+
+        @Override
+        protected int calcHashCode() {
+            int result = 17;
+            result = 31 * result + identifier;
+            result = 31 * result + (managedAddressConfigurationFlag ? 1231 : 1237);
+            result = 31 * result + (otherStatefulConfigurationFlag ? 1231 : 1237);
+            result = 31 * result + reserved;
+            result = 31 * result + options.hashCode();
+            return result;
+        }
+
+    }
+}

--- a/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6MobilePrefixSolicitationPacket.java
+++ b/pcap4j-core/src/main/java/org/pcap4j/packet/IcmpV6MobilePrefixSolicitationPacket.java
@@ -1,0 +1,226 @@
+package org.pcap4j.packet;
+
+import static org.pcap4j.util.ByteArrays.SHORT_SIZE_IN_BYTES;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.pcap4j.packet.AbstractPacket;
+import org.pcap4j.packet.IllegalRawDataException;
+import org.pcap4j.packet.Packet;
+import org.pcap4j.packet.factory.PacketFactories;
+import org.pcap4j.packet.namednumber.NotApplicable;
+import org.pcap4j.util.ByteArrays;
+
+/**
+ * Icmpv6 mobile prefix solicitation packet.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc3775">RFC 3775</a>
+ * @see <a href="https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-codes-24">ICMPv6 Parameters</a>
+ * @author Leo Ma
+ * @since pcap4j 1.7.5
+ */
+public class IcmpV6MobilePrefixSolicitationPacket extends AbstractPacket {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = -6996114480884459960L;
+
+    private final IcmpV6MobilePrefixSolicitationHeader header;
+
+    /**
+     * A static factory method.
+     * This method validates the arguments by {@link ByteArrays#validateBounds(byte[], int, int)},
+     * which may throw exceptions undocumented here.
+     * 
+     * @param rawData rawData
+     * @param offset offset
+     * @param length length
+     * @return a new IcmpV6MobilePrefixSolicitationPacket object.
+     * @throws IllegalRawDataException if parsing the raw data fails.
+     */
+    public static IcmpV6MobilePrefixSolicitationPacket newPacket(
+            byte[] rawData, int offset, int length) throws IllegalRawDataException {
+        ByteArrays.validateBounds(rawData, offset, length);
+        return new IcmpV6MobilePrefixSolicitationPacket(rawData, offset, length);
+    }
+
+    private IcmpV6MobilePrefixSolicitationPacket(
+            byte[] rawData, int offset, int length) throws IllegalRawDataException {
+        this.header = new IcmpV6MobilePrefixSolicitationHeader(rawData, offset, length);
+    }
+
+    private IcmpV6MobilePrefixSolicitationPacket(Builder builder) {
+        this.header = new IcmpV6MobilePrefixSolicitationHeader(builder);
+    }
+
+    @Override
+    public IcmpV6MobilePrefixSolicitationHeader getHeader() {
+        return header;
+    }
+
+    @Override
+    public Builder getBuilder() {
+        return new Builder(this);
+    }
+
+    public static final class Builder extends AbstractBuilder {
+
+        private short identifier;
+        private short reserved;
+
+        /**
+         *
+         */
+        public Builder() {
+            // Do nothing, just used to create a Builder without fields setting
+        }
+
+        private Builder(IcmpV6MobilePrefixSolicitationPacket packet) {
+            this.identifier = packet.header.identifier;
+            this.reserved = packet.header.reserved;
+        }
+
+        /**
+         * @param identifier identifier
+         * @return this Builder object for method chaining.
+         */
+        public Builder identifier(short identifier) {
+            this.identifier = identifier;
+            return this;
+        }
+
+        /**
+         * @param reserved reserved
+         * @return this Builder object for method chaining.
+         */
+        public Builder reserved(short reserved) {
+            this.reserved = reserved;
+            return this;
+        }
+
+        @Override
+        public IcmpV6MobilePrefixSolicitationPacket build() {
+            return new IcmpV6MobilePrefixSolicitationPacket(this);
+        }
+
+    }
+
+    public static final class IcmpV6MobilePrefixSolicitationHeader extends AbstractHeader {
+
+        /*
+         *  0                            15                              31
+         * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         * |          Identifier           |            Reserved           |
+         * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         */
+
+        /**
+         *
+         */
+        private static final long serialVersionUID = -2991706817314703570L;
+
+        private static final int IDENTIFIER_OFFSET = 0;
+        private static final int IDENTIFIER_SIZE = SHORT_SIZE_IN_BYTES;
+        private static final int RESERVED_OFFSET = IDENTIFIER_OFFSET + IDENTIFIER_SIZE;
+        private static final int RESERVED_SIZE = SHORT_SIZE_IN_BYTES;
+        private static final int ICMPV6_MOBILE_PREFIX_SOLICITATION_HEADER_SIZE = RESERVED_OFFSET + RESERVED_SIZE;
+
+        private final short identifier;
+        private final short reserved;
+
+        private IcmpV6MobilePrefixSolicitationHeader(byte[] rawData, int offset, int length)
+                throws IllegalRawDataException {
+            if (length < ICMPV6_MOBILE_PREFIX_SOLICITATION_HEADER_SIZE) {
+                StringBuilder sb = new StringBuilder();
+                sb.append("The data is too short to build an ICMPv6 Mobile Prefix Solicitation Header(")
+                        .append(ICMPV6_MOBILE_PREFIX_SOLICITATION_HEADER_SIZE)
+                        .append(" bytes). data: ")
+                        .append(ByteArrays.toHexString(rawData, " "))
+                        .append(", offset: ")
+                        .append(offset)
+                        .append(", length: ")
+                        .append(length);
+                throw new IllegalRawDataException(sb.toString());
+            }
+            this.identifier = ByteArrays.getShort(rawData, IDENTIFIER_OFFSET + offset);
+            this.reserved = ByteArrays.getShort(rawData, RESERVED_OFFSET + offset);
+        }
+
+        private IcmpV6MobilePrefixSolicitationHeader(Builder builder) {
+            this.identifier = builder.identifier;
+            this.reserved = builder.reserved;
+        }
+
+        public short getIdentifier() {
+            return identifier;
+        }
+
+        public int getIdentifierAsInt() {
+            return identifier & 0xFFFF;
+          }
+
+        public short getReserved() {
+            return reserved;
+        }
+
+        @Override
+        protected List<byte[]> getRawFields() {
+            List<byte[]> rawFields = new ArrayList<byte[]>();
+            rawFields.add(ByteArrays.toByteArray(identifier));
+            rawFields.add(ByteArrays.toByteArray(reserved));
+            return rawFields;
+        }
+
+        @Override
+        public int length() {
+            return ICMPV6_MOBILE_PREFIX_SOLICITATION_HEADER_SIZE;
+
+        }
+
+        @Override
+        protected String buildString() {
+            StringBuilder sb = new StringBuilder();
+            String ls = System.getProperty("line.separator");
+
+            sb.append("[ICMPv6 Mobile Prefix Solicitation Header (")
+                    .append(length())
+                    .append(" bytes)]")
+                    .append(ls);
+            sb.append("  Identifier: ")
+                    .append(getIdentifierAsInt())
+                    .append(ls);
+            sb.append("  Reserved: ")
+                    .append(reserved)
+                    .append(ls);
+            return sb.toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (!this.getClass().isInstance(obj)) {
+                return false;
+            }
+
+            IcmpV6MobilePrefixSolicitationHeader other = (IcmpV6MobilePrefixSolicitationHeader) obj;
+            return this.identifier == other.identifier
+                    && this.reserved == other.reserved;
+        }
+
+        @Override
+        protected int calcHashCode() {
+            int result = 17;
+            result = 31 * result + identifier;
+            result = 31 * result + reserved;
+            return result;
+        }
+
+    }
+}

--- a/pcap4j-packetfactory-propertiesbased/src/main/java/org/pcap4j/packet/factory/packet-factory.properties
+++ b/pcap4j-packetfactory-propertiesbased/src/main/java/org/pcap4j/packet/factory/packet-factory.properties
@@ -61,6 +61,10 @@ org.pcap4j.packet.Packet.classFor.org.pcap4j.packet.namednumber.IcmpV6Type.134 =
 org.pcap4j.packet.Packet.classFor.org.pcap4j.packet.namednumber.IcmpV6Type.135 = org.pcap4j.packet.IcmpV6NeighborSolicitationPacket
 org.pcap4j.packet.Packet.classFor.org.pcap4j.packet.namednumber.IcmpV6Type.136 = org.pcap4j.packet.IcmpV6NeighborAdvertisementPacket
 org.pcap4j.packet.Packet.classFor.org.pcap4j.packet.namednumber.IcmpV6Type.137 = org.pcap4j.packet.IcmpV6RedirectPacket
+org.pcap4j.packet.Packet.classFor.org.pcap4j.packet.namednumber.IcmpV6Type.144 = org.pcap4j.packet.IcmpV6HomeAgentAddressDiscoveryRequest
+org.pcap4j.packet.Packet.classFor.org.pcap4j.packet.namednumber.IcmpV6Type.145 = org.pcap4j.packet.IcmpV6HomeAgentAddressDiscoveryReply
+org.pcap4j.packet.Packet.classFor.org.pcap4j.packet.namednumber.IcmpV6Type.146 = org.pcap4j.packet.IcmpV6MobilePrefixSolicitation
+org.pcap4j.packet.Packet.classFor.org.pcap4j.packet.namednumber.IcmpV6Type.147 = org.pcap4j.packet.IcmpV6MobilePrefixAdvertisement
 
 ## TCP Port (http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xml)
 org.pcap4j.packet.Packet.classFor.org.pcap4j.packet.namednumber.TcpPort.53 = org.pcap4j.packet.DnsPacket

--- a/pcap4j-packetfactory-static/src/main/java/org/pcap4j/packet/factory/StaticIcmpV6TypePacketFactory.java
+++ b/pcap4j-packetfactory-static/src/main/java/org/pcap4j/packet/factory/StaticIcmpV6TypePacketFactory.java
@@ -10,6 +10,10 @@ package org.pcap4j.packet.factory;
 import org.pcap4j.packet.IcmpV6DestinationUnreachablePacket;
 import org.pcap4j.packet.IcmpV6EchoReplyPacket;
 import org.pcap4j.packet.IcmpV6EchoRequestPacket;
+import org.pcap4j.packet.IcmpV6HomeAgentAddressDiscoveryReplyPacket;
+import org.pcap4j.packet.IcmpV6HomeAgentAddressDiscoveryRequestPacket;
+import org.pcap4j.packet.IcmpV6MobilePrefixAdvertisementPacket;
+import org.pcap4j.packet.IcmpV6MobilePrefixSolicitationPacket;
 import org.pcap4j.packet.IcmpV6NeighborAdvertisementPacket;
 import org.pcap4j.packet.IcmpV6NeighborSolicitationPacket;
 import org.pcap4j.packet.IcmpV6PacketTooBigPacket;
@@ -184,6 +188,62 @@ extends AbstractStaticPacketFactory<IcmpV6Type> {
         @Override
         public Class<IcmpV6RedirectPacket> getTargetClass() {
           return IcmpV6RedirectPacket.class;
+        }
+      }
+    );
+    instantiaters.put(
+      IcmpV6Type.HOME_AGENT_ADDRESS_DISCOVERY_REQUEST, new PacketInstantiater() {
+        @Override
+        public Packet newInstance(
+          byte[] rawData, int offset, int length
+        ) throws IllegalRawDataException {
+          return IcmpV6HomeAgentAddressDiscoveryRequestPacket.newPacket(rawData, offset, length);
+        }
+        @Override
+        public Class<IcmpV6HomeAgentAddressDiscoveryRequestPacket> getTargetClass() {
+          return IcmpV6HomeAgentAddressDiscoveryRequestPacket.class;
+        }
+      }
+    );
+    instantiaters.put(
+      IcmpV6Type.HOME_AGENT_ADDRESS_DISCOVERY_REPLY, new PacketInstantiater() {
+        @Override
+        public Packet newInstance(
+          byte[] rawData, int offset, int length
+        ) throws IllegalRawDataException {
+          return IcmpV6HomeAgentAddressDiscoveryReplyPacket.newPacket(rawData, offset, length);
+        }
+        @Override
+        public Class<IcmpV6HomeAgentAddressDiscoveryReplyPacket> getTargetClass() {
+          return IcmpV6HomeAgentAddressDiscoveryReplyPacket.class;
+        }
+      }
+    );
+    instantiaters.put(
+      IcmpV6Type.MOBILE_PREFIX_SOLICITATION, new PacketInstantiater() {
+        @Override
+        public Packet newInstance(
+          byte[] rawData, int offset, int length
+        ) throws IllegalRawDataException {
+          return IcmpV6MobilePrefixSolicitationPacket.newPacket(rawData, offset, length);
+        }
+        @Override
+        public Class<IcmpV6MobilePrefixSolicitationPacket> getTargetClass() {
+          return IcmpV6MobilePrefixSolicitationPacket.class;
+        }
+      }
+    );
+    instantiaters.put(
+      IcmpV6Type.MOBILE_PREFIX_ADVERTISEMENT, new PacketInstantiater() {
+        @Override
+        public Packet newInstance(
+          byte[] rawData, int offset, int length
+        ) throws IllegalRawDataException {
+          return IcmpV6MobilePrefixAdvertisementPacket.newPacket(rawData, offset, length);
+        }
+        @Override
+        public Class<IcmpV6MobilePrefixAdvertisementPacket> getTargetClass() {
+          return IcmpV6MobilePrefixAdvertisementPacket.class;
         }
       }
     );

--- a/pcap4j-packettest/src/test/java/org/pcap4j/packet/IcmpV6HomeAgentAddressDiscoveryReplyPacketTest.java
+++ b/pcap4j-packettest/src/test/java/org/pcap4j/packet/IcmpV6HomeAgentAddressDiscoveryReplyPacketTest.java
@@ -1,0 +1,128 @@
+package org.pcap4j.packet;
+
+import static org.junit.Assert.*;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pcap4j.packet.EthernetPacket;
+import org.pcap4j.packet.IcmpV6CommonPacket;
+import org.pcap4j.packet.IcmpV6HomeAgentAddressDiscoveryReplyPacket.IcmpV6HomeAgentAddressDiscoveryReplyHeader;
+import org.pcap4j.packet.IllegalRawDataException;
+import org.pcap4j.packet.IpV6Packet;
+import org.pcap4j.packet.IpV6SimpleFlowLabel;
+import org.pcap4j.packet.IpV6SimpleTrafficClass;
+import org.pcap4j.packet.Packet;
+import org.pcap4j.packet.SimpleBuilder;
+import org.pcap4j.packet.UnknownPacket;
+import org.pcap4j.packet.namednumber.EtherType;
+import org.pcap4j.packet.namednumber.IcmpV6Code;
+import org.pcap4j.packet.namednumber.IcmpV6Type;
+import org.pcap4j.packet.namednumber.IpNumber;
+import org.pcap4j.packet.namednumber.IpVersion;
+import org.pcap4j.util.MacAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IcmpV6HomeAgentAddressDiscoveryReplyPacketTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(IcmpV6HomeAgentAddressDiscoveryReplyPacketTest.class);
+
+    private final IcmpV6HomeAgentAddressDiscoveryReplyPacket packet;
+    private final short identifier;
+    private final short reserved;
+    private final List<Inet6Address> homeAgentAddresses = new ArrayList<Inet6Address>();
+
+    public IcmpV6HomeAgentAddressDiscoveryReplyPacketTest() throws UnknownHostException {
+        this.identifier = (short) 1234;
+        this.reserved = (short) 12345;
+        this.homeAgentAddresses.add((Inet6Address) InetAddress.getByName("2001:db8::aaaa:bbbb:0:0"));
+        this.homeAgentAddresses.add((Inet6Address) InetAddress.getByName("2001:db8::aaaa:bbbb:0:1"));
+
+        IcmpV6HomeAgentAddressDiscoveryReplyPacket.Builder b = new IcmpV6HomeAgentAddressDiscoveryReplyPacket.Builder();
+        b.identifier(identifier)
+                .reserved(reserved)
+                .homeAgentAddresses(homeAgentAddresses);
+        this.packet = b.build();
+    }
+
+    public Packet getPacket() {
+        return packet;
+    }
+
+    protected Packet getWholePacket() {
+        Inet6Address srcAddr;
+        Inet6Address dstAddr;
+        try {
+            srcAddr = (Inet6Address) InetAddress.getByName("2001:db8::3:2:2");
+            dstAddr = (Inet6Address) InetAddress.getByName("2001:db8::3:2:1");
+        } catch (UnknownHostException e) {
+            throw new AssertionError();
+        }
+        IcmpV6CommonPacket.Builder icmpV6b = new IcmpV6CommonPacket.Builder();
+        icmpV6b.type(IcmpV6Type.HOME_AGENT_ADDRESS_DISCOVERY_REPLY)
+                .code(IcmpV6Code.NO_CODE)
+                .srcAddr(srcAddr)
+                .dstAddr(dstAddr)
+                .payloadBuilder(new SimpleBuilder(packet))
+                .correctChecksumAtBuild(true);
+
+        IpV6Packet.Builder ipv6b = new IpV6Packet.Builder();
+        ipv6b.version(IpVersion.IPV6)
+                .trafficClass(IpV6SimpleTrafficClass.newInstance((byte) 0x12))
+                .flowLabel(IpV6SimpleFlowLabel.newInstance(0x12345))
+                .nextHeader(IpNumber.ICMPV6)
+                .hopLimit((byte) 100)
+                .srcAddr(srcAddr)
+                .dstAddr(dstAddr)
+                .correctLengthAtBuild(true)
+                .payloadBuilder(icmpV6b);
+
+        EthernetPacket.Builder eb = new EthernetPacket.Builder();
+        eb.dstAddr(MacAddress.getByName("fe:00:00:00:00:02"))
+                .srcAddr(MacAddress.getByName("fe:00:00:00:00:01"))
+                .type(EtherType.IPV6)
+                .payloadBuilder(ipv6b)
+                .paddingAtBuild(true);
+        return eb.build();
+    }
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        logger.info(
+                "########## " + IcmpV6HomeAgentAddressDiscoveryReplyPacketTest.class.getSimpleName()
+                        + " START ##########");
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {}
+
+    @Test
+    public void testNewPacket() {
+        IcmpV6HomeAgentAddressDiscoveryReplyPacket p;
+        try {
+            p = IcmpV6HomeAgentAddressDiscoveryReplyPacket.newPacket(packet.getRawData(), 0,
+                    packet.getRawData().length);
+        } catch (IllegalRawDataException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Test
+    public void testGetHeader() {
+        IcmpV6HomeAgentAddressDiscoveryReplyHeader h = packet.getHeader();
+        assertEquals(identifier, h.getIdentifier());
+        assertEquals(reserved, h.getReserved());
+        assertEquals(homeAgentAddresses, h.getHomeAgentAddresses());
+    }
+
+    @Test
+    public void testGetWholePacket() {
+        System.out.println(getWholePacket().toString());
+    }
+
+}

--- a/pcap4j-packettest/src/test/java/org/pcap4j/packet/IcmpV6HomeAgentAddressDiscoveryRequestPacketTest.java
+++ b/pcap4j-packettest/src/test/java/org/pcap4j/packet/IcmpV6HomeAgentAddressDiscoveryRequestPacketTest.java
@@ -1,0 +1,123 @@
+package org.pcap4j.packet;
+
+import static org.junit.Assert.*;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pcap4j.packet.EthernetPacket;
+import org.pcap4j.packet.IcmpV6CommonPacket;
+import org.pcap4j.packet.IcmpV6HomeAgentAddressDiscoveryRequestPacket.IcmpV6HomeAgentAddressDiscoveryRequestHeader;
+import org.pcap4j.packet.IllegalRawDataException;
+import org.pcap4j.packet.IpV6Packet;
+import org.pcap4j.packet.IpV6SimpleFlowLabel;
+import org.pcap4j.packet.IpV6SimpleTrafficClass;
+import org.pcap4j.packet.Packet;
+import org.pcap4j.packet.SimpleBuilder;
+import org.pcap4j.packet.UnknownPacket;
+import org.pcap4j.packet.namednumber.EtherType;
+import org.pcap4j.packet.namednumber.IcmpV6Code;
+import org.pcap4j.packet.namednumber.IcmpV6Type;
+import org.pcap4j.packet.namednumber.IpNumber;
+import org.pcap4j.packet.namednumber.IpVersion;
+import org.pcap4j.util.MacAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("javadoc")
+public class IcmpV6HomeAgentAddressDiscoveryRequestPacketTest {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(IcmpV6HomeAgentAddressDiscoveryRequestPacketTest.class);
+    private final IcmpV6HomeAgentAddressDiscoveryRequestPacket packet;
+    private final short identifier;
+    private final short reserved;
+
+    public IcmpV6HomeAgentAddressDiscoveryRequestPacketTest() {
+        this.identifier = (short) 1234;
+        this.reserved = (short) 12345;
+
+        IcmpV6HomeAgentAddressDiscoveryRequestPacket.Builder b = new IcmpV6HomeAgentAddressDiscoveryRequestPacket.Builder();
+        b.identifier(identifier)
+                .reserved(reserved);
+        this.packet = b.build();
+    }
+
+    public Packet getPacket() {
+        return packet;
+    }
+
+    protected Packet getWholePacket() {
+        Inet6Address srcAddr;
+        Inet6Address dstAddr;
+        try {
+            srcAddr = (Inet6Address) InetAddress.getByName("2001:db8::3:2:2");
+            dstAddr = (Inet6Address) InetAddress.getByName("2001:db8::3:2:1");
+        } catch (UnknownHostException e) {
+            throw new AssertionError();
+        }
+        IcmpV6CommonPacket.Builder icmpV6b = new IcmpV6CommonPacket.Builder();
+        icmpV6b.type(IcmpV6Type.HOME_AGENT_ADDRESS_DISCOVERY_REQUEST)
+                .code(IcmpV6Code.NO_CODE)
+                .srcAddr(srcAddr)
+                .dstAddr(dstAddr)
+                .payloadBuilder(new SimpleBuilder(packet))
+                .correctChecksumAtBuild(true);
+
+        IpV6Packet.Builder ipv6b = new IpV6Packet.Builder();
+        ipv6b.version(IpVersion.IPV6)
+                .trafficClass(IpV6SimpleTrafficClass.newInstance((byte) 0x12))
+                .flowLabel(IpV6SimpleFlowLabel.newInstance(0x12345))
+                .nextHeader(IpNumber.ICMPV6)
+                .hopLimit((byte) 100)
+                .srcAddr(srcAddr)
+                .dstAddr(dstAddr)
+                .correctLengthAtBuild(true)
+                .payloadBuilder(icmpV6b);
+
+        EthernetPacket.Builder eb = new EthernetPacket.Builder();
+        eb.dstAddr(MacAddress.getByName("fe:00:00:00:00:02"))
+                .srcAddr(MacAddress.getByName("fe:00:00:00:00:01"))
+                .type(EtherType.IPV6)
+                .payloadBuilder(ipv6b)
+                .paddingAtBuild(true);
+        return eb.build();
+
+    }
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        logger.info(
+                "########## " + IcmpV6HomeAgentAddressDiscoveryRequestPacketTest.class.getSimpleName()
+                        + " START ##########");
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {}
+
+    @Test
+    public void testNewPacket() {
+        IcmpV6HomeAgentAddressDiscoveryRequestPacket p;
+        try {
+            p = IcmpV6HomeAgentAddressDiscoveryRequestPacket.newPacket(packet.getRawData(), 0,
+                    packet.getRawData().length);
+        } catch (IllegalRawDataException e) {
+            throw new AssertionError(e);
+        }
+
+    }
+
+    @Test
+    public void testGetHeader() {
+        IcmpV6HomeAgentAddressDiscoveryRequestHeader h = packet.getHeader();
+        assertEquals(identifier, h.getIdentifier());
+        assertEquals(reserved, h.getReserved());
+    }
+
+    @Test
+    public void testGetWholePacket() {
+        System.out.println(getWholePacket().toString());
+    }
+}

--- a/pcap4j-packettest/src/test/java/org/pcap4j/packet/IcmpV6MobilePrefixAdvertisementPacketTest.java
+++ b/pcap4j-packettest/src/test/java/org/pcap4j/packet/IcmpV6MobilePrefixAdvertisementPacketTest.java
@@ -1,0 +1,188 @@
+package org.pcap4j.packet;
+
+import static org.junit.Assert.*;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pcap4j.packet.EthernetPacket;
+import org.pcap4j.packet.IcmpV6CommonPacket;
+import org.pcap4j.packet.IcmpV6CommonPacket.IpV6NeighborDiscoveryOption;
+import org.pcap4j.packet.IllegalRawDataException;
+import org.pcap4j.packet.IpV6NeighborDiscoveryMtuOption;
+import org.pcap4j.packet.IpV6NeighborDiscoveryPrefixInformationOption;
+import org.pcap4j.packet.IpV6NeighborDiscoverySourceLinkLayerAddressOption;
+import org.pcap4j.packet.IpV6Packet;
+import org.pcap4j.packet.IpV6SimpleFlowLabel;
+import org.pcap4j.packet.IpV6SimpleTrafficClass;
+import org.pcap4j.packet.Packet;
+import org.pcap4j.packet.SimpleBuilder;
+import org.pcap4j.packet.namednumber.EtherType;
+import org.pcap4j.packet.namednumber.IcmpV6Code;
+import org.pcap4j.packet.namednumber.IcmpV6Type;
+import org.pcap4j.packet.namednumber.IpNumber;
+import org.pcap4j.packet.namednumber.IpVersion;
+import org.pcap4j.util.MacAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("javadoc")
+public class IcmpV6MobilePrefixAdvertisementPacketTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(IcmpV6MobilePrefixAdvertisementPacketTest.class);
+
+    private final IcmpV6MobilePrefixAdvertisementPacket packet;
+    private final short identifier;
+    private final boolean managedAddressConfigurationFlag; // M field
+    private final boolean otherStatefulConfigurationFlag; // O field
+    private final short reserved;
+    private final List<IpV6NeighborDiscoveryOption> options = new ArrayList<IpV6NeighborDiscoveryOption>();
+
+    public IcmpV6MobilePrefixAdvertisementPacketTest() throws UnknownHostException {
+        this.identifier = (short) 1234;
+        this.managedAddressConfigurationFlag = true;
+        this.otherStatefulConfigurationFlag = false;
+        this.reserved = (byte) 10;
+        IpV6NeighborDiscoverySourceLinkLayerAddressOption.Builder opt1 = new IpV6NeighborDiscoverySourceLinkLayerAddressOption.Builder();
+        opt1.linkLayerAddress(
+                new byte[] {
+                        (byte) 0xff, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x02, (byte) 0x03
+                })
+                .correctLengthAtBuild(true);
+        this.options.add(opt1.build());
+
+        IpV6NeighborDiscoveryMtuOption.Builder opt2 = new IpV6NeighborDiscoveryMtuOption.Builder();
+        opt2.reserved((byte) 222)
+                .mtu(9999999)
+                .correctLengthAtBuild(true);
+        this.options.add(opt2.build());
+
+        IpV6NeighborDiscoveryPrefixInformationOption.Builder opt3 = new IpV6NeighborDiscoveryPrefixInformationOption.Builder();
+        opt3.prefixLength((byte) 96)
+                .onLinkFlag(true)
+                .addressConfigurationFlag(false)
+                .reserved1((byte) 22)
+                .validLifetime(2222222)
+                .preferredLifetime(777777777)
+                .reserved2(1212121212)
+                .prefix((Inet6Address) InetAddress.getByName("2001:db8::aaaa:bbbb:0:0"))
+                .correctLengthAtBuild(true);
+        this.options.add(opt3.build());
+
+        IcmpV6MobilePrefixAdvertisementPacket.Builder b = new IcmpV6MobilePrefixAdvertisementPacket.Builder();
+        b.identifier(identifier)
+                .managedAddressConfigurationFlag(managedAddressConfigurationFlag)
+                .otherStatefulConfigurationFlag(otherStatefulConfigurationFlag)
+                .reserved(reserved)
+                .options(options);
+        this.packet = b.build();
+    }
+
+    protected Packet getPacket() {
+        return packet;
+    }
+
+    protected Packet getWholePacket() {
+        Inet6Address srcAddr;
+        Inet6Address dstAddr;
+        try {
+            srcAddr = (Inet6Address) InetAddress.getByName("2001:db8::3:2:1");
+            dstAddr = (Inet6Address) InetAddress.getByName("2001:db8::3:2:2");
+        } catch (UnknownHostException e) {
+            throw new AssertionError();
+        }
+        IcmpV6CommonPacket.Builder icmpV6b = new IcmpV6CommonPacket.Builder();
+        icmpV6b.type(IcmpV6Type.MOBILE_PREFIX_ADVERTISEMENT)
+                .code(IcmpV6Code.NO_CODE)
+                .srcAddr(srcAddr)
+                .dstAddr(dstAddr)
+                .payloadBuilder(new SimpleBuilder(packet))
+                .correctChecksumAtBuild(true);
+
+        IpV6Packet.Builder ipv6b = new IpV6Packet.Builder();
+        ipv6b.version(IpVersion.IPV6)
+                .trafficClass(IpV6SimpleTrafficClass.newInstance((byte) 0x12))
+                .flowLabel(IpV6SimpleFlowLabel.newInstance(0x12345))
+                .nextHeader(IpNumber.ICMPV6)
+                .hopLimit((byte) 100)
+                .srcAddr(srcAddr)
+                .dstAddr(dstAddr)
+                .correctLengthAtBuild(true)
+                .payloadBuilder(icmpV6b);
+
+        EthernetPacket.Builder eb = new EthernetPacket.Builder();
+        eb.dstAddr(MacAddress.getByName("fe:00:00:00:00:02"))
+                .srcAddr(MacAddress.getByName("fe:00:00:00:00:01"))
+                .type(EtherType.IPV6)
+                .payloadBuilder(ipv6b)
+                .paddingAtBuild(true);
+        return eb.build();
+    }
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        logger.info(
+                "########## " + IcmpV6MobilePrefixAdvertisementPacketTest.class.getSimpleName() + " START ##########");
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {}
+
+    @Test
+    public void testNewPacket() {
+        try {
+            IcmpV6MobilePrefixAdvertisementPacket p = IcmpV6MobilePrefixAdvertisementPacket
+                    .newPacket(packet.getRawData(), 0, packet.getRawData().length);
+            assertEquals(packet, p);
+        } catch (IllegalRawDataException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Test
+    public void testGetHeader() {
+        IcmpV6MobilePrefixAdvertisementPacket.IcmpV6MobilePrefixAdvertisementHeader h = packet.getHeader();
+        assertEquals(identifier, h.getIdentifier());
+        assertEquals(managedAddressConfigurationFlag, h.isManagedAddressConfigurationFlag());
+        assertEquals(otherStatefulConfigurationFlag, h.isOtherStatefulConfigurationFlag());
+        assertEquals(reserved, h.getReserved());
+        Iterator<IpV6NeighborDiscoveryOption> iter = h.getOptions().iterator();
+        for (IpV6NeighborDiscoveryOption expected : options) {
+            IpV6NeighborDiscoveryOption actual = iter.next();
+            assertEquals(expected, actual);
+        }
+
+        IcmpV6MobilePrefixAdvertisementPacket.Builder b = packet.getBuilder();
+        IcmpV6MobilePrefixAdvertisementPacket p;
+
+        b.reserved((byte) 0);
+        p = b.build();
+        assertEquals((byte) 0, p.getHeader().getReserved());
+
+        b.reserved((byte) 63);
+        p = b.build();
+        assertEquals((byte) 63, p.getHeader().getReserved());
+
+        b.reserved((byte) 64);
+        try {
+            p = b.build();
+        } catch (IllegalArgumentException e) {}
+
+        b.reserved((byte) -1);
+        try {
+            p = b.build();
+        } catch (IllegalArgumentException e) {}
+
+    }
+
+    @Test
+    public void testGetWholePacket() {
+        System.out.println(getWholePacket().toString());
+    }
+
+}

--- a/pcap4j-packettest/src/test/java/org/pcap4j/packet/IcmpV6MobilePrefixSolicitationPacketTest.java
+++ b/pcap4j-packettest/src/test/java/org/pcap4j/packet/IcmpV6MobilePrefixSolicitationPacketTest.java
@@ -1,0 +1,121 @@
+package org.pcap4j.packet;
+
+import static org.junit.Assert.*;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pcap4j.packet.EthernetPacket;
+import org.pcap4j.packet.IcmpV6CommonPacket;
+import org.pcap4j.packet.IcmpV6MobilePrefixSolicitationPacket.IcmpV6MobilePrefixSolicitationHeader;
+import org.pcap4j.packet.IllegalRawDataException;
+import org.pcap4j.packet.IpV6Packet;
+import org.pcap4j.packet.IpV6SimpleFlowLabel;
+import org.pcap4j.packet.IpV6SimpleTrafficClass;
+import org.pcap4j.packet.Packet;
+import org.pcap4j.packet.SimpleBuilder;
+import org.pcap4j.packet.UnknownPacket;
+import org.pcap4j.packet.namednumber.EtherType;
+import org.pcap4j.packet.namednumber.IcmpV6Code;
+import org.pcap4j.packet.namednumber.IcmpV6Type;
+import org.pcap4j.packet.namednumber.IpNumber;
+import org.pcap4j.packet.namednumber.IpVersion;
+import org.pcap4j.util.MacAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("javadoc")
+public class IcmpV6MobilePrefixSolicitationPacketTest {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(IcmpV6HomeAgentAddressDiscoveryRequestPacketTest.class);
+    private final IcmpV6MobilePrefixSolicitationPacket packet;
+    private final short identifier;
+    private final short reserved;
+
+    public IcmpV6MobilePrefixSolicitationPacketTest() {
+        this.identifier = (short) 1234;
+        this.reserved = (short) 12345;
+
+        IcmpV6MobilePrefixSolicitationPacket.Builder b = new IcmpV6MobilePrefixSolicitationPacket.Builder();
+        b.identifier(identifier)
+                .reserved(reserved);
+        this.packet = b.build();
+    }
+
+    public Packet getPacket() {
+        return packet;
+    }
+
+    protected Packet getWholePacket() {
+        Inet6Address srcAddr;
+        Inet6Address dstAddr;
+        try {
+            srcAddr = (Inet6Address) InetAddress.getByName("2001:db8::3:2:2");
+            dstAddr = (Inet6Address) InetAddress.getByName("2001:db8::3:2:1");
+        } catch (UnknownHostException e) {
+            throw new AssertionError();
+        }
+        IcmpV6CommonPacket.Builder icmpV6b = new IcmpV6CommonPacket.Builder();
+        icmpV6b.type(IcmpV6Type.MOBILE_PREFIX_SOLICITATION)
+                .code(IcmpV6Code.NO_CODE)
+                .srcAddr(srcAddr)
+                .dstAddr(dstAddr)
+                .payloadBuilder(new SimpleBuilder(packet))
+                .correctChecksumAtBuild(true);
+
+        IpV6Packet.Builder ipv6b = new IpV6Packet.Builder();
+        ipv6b.version(IpVersion.IPV6)
+                .trafficClass(IpV6SimpleTrafficClass.newInstance((byte) 0x12))
+                .flowLabel(IpV6SimpleFlowLabel.newInstance(0x12345))
+                .nextHeader(IpNumber.ICMPV6)
+                .hopLimit((byte) 100)
+                .srcAddr(srcAddr)
+                .dstAddr(dstAddr)
+                .correctLengthAtBuild(true)
+                .payloadBuilder(icmpV6b);
+
+        EthernetPacket.Builder eb = new EthernetPacket.Builder();
+        eb.dstAddr(MacAddress.getByName("fe:00:00:00:00:02"))
+                .srcAddr(MacAddress.getByName("fe:00:00:00:00:01"))
+                .type(EtherType.IPV6)
+                .payloadBuilder(ipv6b)
+                .paddingAtBuild(true);
+        return eb.build();
+
+    }
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        logger.info(
+                "########## " + IcmpV6MobilePrefixSolicitationPacketTest.class.getSimpleName() + " START ##########");
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {}
+
+    @Test
+    public void testNewPacket() {
+        IcmpV6MobilePrefixSolicitationPacket p;
+        try {
+            p = IcmpV6MobilePrefixSolicitationPacket.newPacket(packet.getRawData(), 0, packet.getRawData().length);
+        } catch (IllegalRawDataException e) {
+            throw new AssertionError(e);
+        }
+
+    }
+
+    @Test
+    public void testGetHeader() {
+        IcmpV6MobilePrefixSolicitationHeader h = packet.getHeader();
+        assertEquals(identifier, h.getIdentifier());
+        assertEquals(reserved, h.getReserved());
+    }
+
+    @Test
+    public void testGetWholePacket() {
+        System.out.println(getWholePacket().toString());
+    }
+}


### PR DESCRIPTION
 - HOME_AGENT_ADDRESS_DISCOVERY_REQUEST
 - HOME_AGENT_ADDRESS_DISCOVERY_REPLY
 - MOBILE_PREFIX_SOLICITATION
 - MOBILE_PREFIX_ADVERTISEMENT

Signed-off-by: Leo Ma <leo.ma@ericsson.com>