### PR TITLE
Fix Slf4j-api module, to better represent the Java 9 compatible module name

### DIFF
--- a/pcap4j-core/src/main/java/module-info.java
+++ b/pcap4j-core/src/main/java/module-info.java
@@ -14,7 +14,7 @@ module org.pcap4j.core {
   // These transitive modifiers are needed to avoid weird surefire errors
   // during pcap4j-packetfactory-* testing (due to maybe surefire's bug).
   requires transitive com.sun.jna;
-  requires transitive slf4j.api;
+  requires transitive org.slf4j;
 
   uses org.pcap4j.packet.factory.PacketFactoryBinderProvider;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.26</version>
+        <version>1.8.0-beta4</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
The currently used `slf4j-api` version (1.7.26) has not been made with the new modular system of Java 9 in mind. This means that there isn't a `module-info.java` file in the provided dependency.

To overcome this, in the `org.pcap4j.core` module, the artifact id of the `slf4j-api` has been required.

This, however, isn't compatible with the modular version of `slf4j-api`, which means that users of this _(pcap4j)_ artifact cannot make use of the modular slf4j version, because, during compile, the `requires transitive slf4j.api;` requirement will not be met by the modular `slf4j-api` version.

For this reason, I raised the `slf4j-api` version in the parent POM and made it so that the `org.pcap4j.core` module requires the intended `org.slf4j` module instead.