### PR TITLE
Feature/fix wrong module name slf4j api

### DIFF
--- a/pcap4j-core/src/main/java/module-info.java
+++ b/pcap4j-core/src/main/java/module-info.java
@@ -14,7 +14,7 @@ module org.pcap4j.core {
   // These transitive modifiers are needed to avoid weird surefire errors
   // during pcap4j-packetfactory-* testing (due to maybe surefire's bug).
   requires transitive com.sun.jna;
-  requires transitive slf4j.api;
+  requires transitive org.slf4j;
 
   uses org.pcap4j.packet.factory.PacketFactoryBinderProvider;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,10 @@
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
-        <version>5.3.1</version>
+        <version>5.7.0</version>
+<!--        TO BE RELEASED containing module-info.java-->
+<!--        <artifactId>jna-jpms</artifactId>-->
+<!--        <version>5.8.0</version>-->
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,12 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.0.0</version>
+        <version>1.3.0-alpha5</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
-        <version>1.0.0</version>
+        <version>1.3.0-alpha5</version>
       </dependency>
       <dependency>
         <groupId>net.java.dev.jna</groupId>
@@ -113,7 +113,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.26</version>
+        <version>2.0.0-alpha1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
I could not run the tests since I could not find JDK-6 to easily install it, therefore I will let the CI do its job.

Hopefully, you can release a new version with the correct module naming.